### PR TITLE
Fix Playground image dimension validation

### DIFF
--- a/crates/mayhem-gateway/src/openai/dashboard_pages.rs
+++ b/crates/mayhem-gateway/src/openai/dashboard_pages.rs
@@ -2026,10 +2026,13 @@ fn playground_mode_icon(mode: &str) -> &'static str {
 }
 
 const PLAYGROUND_IMAGE_RATIOS: [(&str, u32, u32, u32); 4] = [
-    ("1:1", 1, 1, 512),
-    ("4:3", 4, 3, 160),
-    ("3:4", 3, 4, 160),
-    ("16:9", 16, 9, 48),
+    ("1:1", 1, 1, 1_024),
+    ("4:3", 4, 3, 288),
+    ("3:4", 3, 4, 288),
+    // Z-Image's proven wide preset is 1344x768, exposed as 16:9 in the
+    // product UI. Preserve that provider-tested shape rather than inventing
+    // an uncalibrated exact-ratio replacement.
+    ("16:9", 7, 4, 192),
 ];
 
 #[derive(Debug, Eq, PartialEq)]
@@ -2071,11 +2074,17 @@ fn playground_image_request_config(model: &GatewayModel) -> Option<PlaygroundIma
     let mut sizes = BTreeMap::new();
 
     for (label, ratio_width, ratio_height, preferred_scale) in PLAYGROUND_IMAGE_RATIOS {
-        let minimum_scale = preferred_scale
-            .max(minimum_width.div_ceil(ratio_width))
+        let minimum_scale = minimum_width
+            .div_ceil(ratio_width)
             .max(minimum_height.div_ceil(ratio_height));
         let maximum_scale = (maximum_width / ratio_width).min(maximum_height / ratio_height);
-        for scale in minimum_scale..=maximum_scale {
+        if minimum_scale > maximum_scale {
+            continue;
+        }
+        let preferred_scale = preferred_scale.clamp(minimum_scale, maximum_scale);
+        let mut candidate_scales = (minimum_scale..=maximum_scale).collect::<Vec<_>>();
+        candidate_scales.sort_by_key(|scale| scale.abs_diff(preferred_scale));
+        for scale in candidate_scales {
             let width = ratio_width.saturating_mul(scale);
             let height = ratio_height.saturating_mul(scale);
             if !signed_dimension_allows(width_spec, width)
@@ -6726,16 +6735,16 @@ mod tests {
 
         let config = playground_image_request_config(&model).expect("image request config");
         assert_eq!(config.dimension_mode, "size");
-        assert_eq!(config.sizes["1:1"], "576x576");
-        assert_eq!(config.sizes["4:3"], "768x576");
-        assert_eq!(config.sizes["3:4"], "576x768");
-        assert_eq!(config.sizes["16:9"], "1024x576");
+        assert_eq!(config.sizes["1:1"], "1024x1024");
+        assert_eq!(config.sizes["4:3"], "1152x864");
+        assert_eq!(config.sizes["3:4"], "864x1152");
+        assert_eq!(config.sizes["16:9"], "1344x768");
         assert!(!config.sizes.values().any(|size| size == "512x512"));
 
         let data = DashboardData::from_state(&GatewayState::from_models(vec![model.clone()]));
         let html = playground_page(&data, 60, Some(&model.id));
         assert!(html.contains(r#"data-image-dimension-mode="size""#));
-        assert!(html.contains(r#"&quot;1:1&quot;:&quot;576x576&quot;"#));
+        assert!(html.contains(r#"&quot;1:1&quot;:&quot;1024x1024&quot;"#));
         assert!(html.contains("data-playground-image-size"));
 
         contract.request_attributes.retain(|path| path != "size");
@@ -6744,7 +6753,7 @@ mod tests {
         let dimensions =
             playground_image_request_config(&model).expect("width-height image request config");
         assert_eq!(dimensions.dimension_mode, "width-height");
-        assert_eq!(dimensions.sizes["1:1"], "576x576");
+        assert_eq!(dimensions.sizes["1:1"], "1024x1024");
     }
 
     #[test]

--- a/crates/mayhem-gateway/src/openai/dashboard_pages.rs
+++ b/crates/mayhem-gateway/src/openai/dashboard_pages.rs
@@ -2025,6 +2025,134 @@ fn playground_mode_icon(mode: &str) -> &'static str {
     }
 }
 
+const PLAYGROUND_IMAGE_RATIOS: [(&str, u32, u32, u32); 4] = [
+    ("1:1", 1, 1, 512),
+    ("4:3", 4, 3, 160),
+    ("3:4", 3, 4, 160),
+    ("16:9", 16, 9, 48),
+];
+
+#[derive(Debug, Eq, PartialEq)]
+struct PlaygroundImageRequestConfig {
+    dimension_mode: &'static str,
+    sizes: BTreeMap<&'static str, String>,
+}
+
+fn playground_image_request_config(model: &GatewayModel) -> Option<PlaygroundImageRequestConfig> {
+    let contract = model
+        .mayhem
+        .adapter
+        .endpoint_families
+        .iter()
+        .find(|contract| contract.family == mayhem_proto::ENDPOINT_OPENAI_IMAGE_GENERATIONS)?;
+    let supports_size = contract
+        .request_attributes
+        .iter()
+        .any(|path| path == "size");
+    let supports_dimensions = ["width", "height"].iter().all(|required| {
+        contract
+            .request_attributes
+            .iter()
+            .any(|path| path == required)
+    });
+    let dimension_mode = if supports_size {
+        "size"
+    } else if supports_dimensions {
+        "width-height"
+    } else {
+        return None;
+    };
+    let width_spec = contract.request_attribute_specs.get("width");
+    let height_spec = contract.request_attribute_specs.get("height");
+    let minimum_width = signed_dimension_minimum(width_spec);
+    let minimum_height = signed_dimension_minimum(height_spec);
+    let maximum_width = signed_dimension_maximum(width_spec, model.mayhem.caps.max_image_width);
+    let maximum_height = signed_dimension_maximum(height_spec, model.mayhem.caps.max_image_height);
+    let mut sizes = BTreeMap::new();
+
+    for (label, ratio_width, ratio_height, preferred_scale) in PLAYGROUND_IMAGE_RATIOS {
+        let minimum_scale = preferred_scale
+            .max(minimum_width.div_ceil(ratio_width))
+            .max(minimum_height.div_ceil(ratio_height));
+        let maximum_scale = (maximum_width / ratio_width).min(maximum_height / ratio_height);
+        for scale in minimum_scale..=maximum_scale {
+            let width = ratio_width.saturating_mul(scale);
+            let height = ratio_height.saturating_mul(scale);
+            if !signed_dimension_allows(width_spec, width)
+                || !signed_dimension_allows(height_spec, height)
+            {
+                continue;
+            }
+            let request = if dimension_mode == "size" {
+                json!({
+                    "model": model.id,
+                    "prompt": "Playground image dimension compatibility check",
+                    "size": format!("{width}x{height}"),
+                })
+            } else {
+                json!({
+                    "model": model.id,
+                    "prompt": "Playground image dimension compatibility check",
+                    "width": width,
+                    "height": height,
+                })
+            };
+            if mayhem_proto::validate_endpoint_request(contract, &request).is_ok() {
+                sizes.insert(label, format!("{width}x{height}"));
+                break;
+            }
+        }
+    }
+
+    Some(PlaygroundImageRequestConfig {
+        dimension_mode,
+        sizes,
+    })
+}
+
+fn signed_dimension_minimum(spec: Option<&mayhem_proto::EndpointAttributeSpec>) -> u32 {
+    spec.and_then(|spec| spec.minimum)
+        .filter(|value| value.is_finite() && *value > 0.0)
+        .map(|value| value.ceil().min(f64::from(u32::MAX)) as u32)
+        .unwrap_or(1)
+}
+
+fn signed_dimension_maximum(
+    spec: Option<&mayhem_proto::EndpointAttributeSpec>,
+    caps_maximum: Option<u32>,
+) -> u32 {
+    let signed_maximum = spec
+        .and_then(|spec| spec.maximum)
+        .filter(|value| value.is_finite() && *value > 0.0)
+        .map(|value| value.floor().min(f64::from(u32::MAX)) as u32)
+        .unwrap_or(4_096);
+    caps_maximum.map_or(signed_maximum, |value| value.min(signed_maximum))
+}
+
+fn signed_dimension_allows(spec: Option<&mayhem_proto::EndpointAttributeSpec>, value: u32) -> bool {
+    let Some(spec) = spec else {
+        return true;
+    };
+    let value = f64::from(value);
+    if spec.minimum.is_some_and(|minimum| value < minimum)
+        || spec.maximum.is_some_and(|maximum| value > maximum)
+    {
+        return false;
+    }
+    if spec.multiple_of.is_some_and(|multiple| {
+        !multiple.is_finite()
+            || multiple <= 0.0
+            || (value / multiple - (value / multiple).round()).abs() > f64::EPSILON * 16.0
+    }) {
+        return false;
+    }
+    spec.enum_values.is_empty()
+        || spec
+            .enum_values
+            .iter()
+            .any(|candidate| candidate.as_u64() == Some(value as u64))
+}
+
 fn playground_page(data: &DashboardData, expires: u64, selected_model: Option<&str>) -> String {
     let credential_needed = data.requires_auth() && data.active_token_count() == 0;
     let mut choices = data
@@ -2095,8 +2223,18 @@ fn playground_page(data: &DashboardData, expires: u64, selected_model: Option<&s
             "speech" => "Natural text to speech",
             _ => "Chat and text generation",
         };
+        let image_attributes =
+            playground_image_request_config(model).map_or_else(String::new, |config| {
+                let sizes =
+                    serde_json::to_string(&config.sizes).unwrap_or_else(|_| "{}".to_owned());
+                format!(
+                    r#" data-image-dimension-mode="{}" data-image-sizes="{}""#,
+                    config.dimension_mode,
+                    html_escape(&sizes),
+                )
+            });
         options.push_str(&format!(
-            r##"<option value="{}" data-playground-mode="{mode}" data-availability="{}" data-price="{}" data-price-mode="{price_mode}" data-location="Network provider route" data-protection="{}" data-context="Up to {context} catalog tokens" data-model-name="{}" data-model-lab="{}" data-model-purpose="{purpose}"{selected}>{} &mdash; {}</option>"##,
+            r##"<option value="{}" data-playground-mode="{mode}" data-availability="{}" data-price="{}" data-price-mode="{price_mode}" data-location="Network provider route" data-protection="{}" data-context="Up to {context} catalog tokens" data-model-name="{}" data-model-lab="{}" data-model-purpose="{purpose}"{image_attributes}{selected}>{} &mdash; {}</option>"##,
             html_escape(&model.id),
             html_escape(availability.label),
             html_escape(&dashboard_model_price(model)),
@@ -2238,7 +2376,7 @@ fn playground_page(data: &DashboardData, expires: u64, selected_model: Option<&s
 
         <section id="playground-image-panel" role="tabpanel" aria-label="Image playground" class="pg-mode-panel" data-playground-mode-panel="image"{image_hidden}>
           <section class="pg-media" aria-label="Image generation playground">
-            <div class="pg-settings"><div class="pg-section-heading"><h2>Generate an image</h2><p>Describe what you want to create.</p></div><label class="pg-field" for="playground-image-prompt"><span>Prompt <em class="pg-count" data-playground-image-count>0/1200</em></span><textarea id="playground-image-prompt" data-playground-image-prompt data-playground-draft maxlength="1200" rows="7" placeholder="A quiet observatory above a sea of clouds…"></textarea></label><fieldset class="pg-ratio-field"><legend>Aspect ratio</legend><div><button type="button" class="is-active" aria-pressed="true" data-playground-aspect-ratio="1:1"><span class="pg-ratio-glyph ratio-1-1" aria-hidden="true"></span>1:1</button><button type="button" aria-pressed="false" data-playground-aspect-ratio="4:3"><span class="pg-ratio-glyph ratio-4-3" aria-hidden="true"></span>4:3</button><button type="button" aria-pressed="false" data-playground-aspect-ratio="3:4"><span class="pg-ratio-glyph ratio-3-4" aria-hidden="true"></span>3:4</button><button type="button" aria-pressed="false" data-playground-aspect-ratio="16:9"><span class="pg-ratio-glyph ratio-16-9" aria-hidden="true"></span>16:9</button></div></fieldset><button type="button" class="pg-primary-action" data-playground-generate-image disabled>{image_icon}<span>Generate image</span></button></div>
+            <div class="pg-settings"><div class="pg-section-heading"><h2>Generate an image</h2><p>Describe what you want to create.</p></div><label class="pg-field" for="playground-image-prompt"><span>Prompt <em class="pg-count" data-playground-image-count>0/1200</em></span><textarea id="playground-image-prompt" data-playground-image-prompt data-playground-draft maxlength="1200" rows="7" placeholder="A quiet observatory above a sea of clouds…"></textarea></label><fieldset class="pg-ratio-field"><legend><span>Aspect ratio</span><em class="pg-count" data-playground-image-size>Model dimensions</em></legend><div><button type="button" class="is-active" aria-pressed="true" data-playground-aspect-ratio="1:1"><span class="pg-ratio-glyph ratio-1-1" aria-hidden="true"></span>1:1</button><button type="button" aria-pressed="false" data-playground-aspect-ratio="4:3"><span class="pg-ratio-glyph ratio-4-3" aria-hidden="true"></span>4:3</button><button type="button" aria-pressed="false" data-playground-aspect-ratio="3:4"><span class="pg-ratio-glyph ratio-3-4" aria-hidden="true"></span>3:4</button><button type="button" aria-pressed="false" data-playground-aspect-ratio="16:9"><span class="pg-ratio-glyph ratio-16-9" aria-hidden="true"></span>16:9</button></div></fieldset><button type="button" class="pg-primary-action" data-playground-generate-image disabled>{image_icon}<span>Generate image</span></button></div>
             <div class="pg-output" data-playground-image-output aria-live="polite"><div class="pg-output-empty">{image_icon}<strong>Image output</strong><span>Your generated image will appear here.</span></div></div>
           </section>
         </section>
@@ -6562,6 +6700,51 @@ mod tests {
         assert!(html.contains("drafts and history stay in this browser tab"));
         assert!(html.contains("access tokens are never saved"));
         assert!(html.contains("data-playground-reset-draft"));
+    }
+
+    #[test]
+    fn playground_image_sizes_follow_the_selected_models_signed_constraints() {
+        let mut model = GatewayState::fixture().models_snapshot()[0].clone();
+        model.id = "test/signed-image".to_owned();
+        model.mayhem.model_class = "image-generation".to_owned();
+        model.mayhem.caps.image = true;
+        model.mayhem.caps.max_image_width = Some(2_048);
+        model.mayhem.caps.max_image_height = Some(2_048);
+        model.mayhem.caps.output_modality = Some("image".to_owned());
+        model.mayhem.caps.output_modalities = vec!["image".to_owned()];
+        let mut contract = mayhem_proto::endpoint_family_contract_template(
+            mayhem_proto::ENDPOINT_OPENAI_IMAGE_GENERATIONS,
+        )
+        .expect("OpenAI image endpoint contract");
+        for path in ["width", "height"] {
+            let spec = contract.request_attribute_specs.get_mut(path).unwrap();
+            spec.minimum = Some(576.0);
+            spec.maximum = Some(2_048.0);
+            spec.multiple_of = Some(16.0);
+        }
+        model.mayhem.adapter.endpoint_families = vec![contract.clone()];
+
+        let config = playground_image_request_config(&model).expect("image request config");
+        assert_eq!(config.dimension_mode, "size");
+        assert_eq!(config.sizes["1:1"], "576x576");
+        assert_eq!(config.sizes["4:3"], "768x576");
+        assert_eq!(config.sizes["3:4"], "576x768");
+        assert_eq!(config.sizes["16:9"], "1024x576");
+        assert!(!config.sizes.values().any(|size| size == "512x512"));
+
+        let data = DashboardData::from_state(&GatewayState::from_models(vec![model.clone()]));
+        let html = playground_page(&data, 60, Some(&model.id));
+        assert!(html.contains(r#"data-image-dimension-mode="size""#));
+        assert!(html.contains(r#"&quot;1:1&quot;:&quot;576x576&quot;"#));
+        assert!(html.contains("data-playground-image-size"));
+
+        contract.request_attributes.retain(|path| path != "size");
+        contract.request_attribute_specs.remove("size");
+        model.mayhem.adapter.endpoint_families = vec![contract];
+        let dimensions =
+            playground_image_request_config(&model).expect("width-height image request config");
+        assert_eq!(dimensions.dimension_mode, "width-height");
+        assert_eq!(dimensions.sizes["1:1"], "576x576");
     }
 
     #[test]

--- a/crates/mayhem-gateway/src/openai/dashboard_ui.rs
+++ b/crates/mayhem-gateway/src/openai/dashboard_ui.rs
@@ -796,6 +796,7 @@ html.js-ready .playground-interactive{min-height:clamp(520px,64vh,720px)}
 .pg-ratio-field>div{display:grid;grid-template-columns:repeat(4,1fr);gap:.35rem}
 .pg-ratio-field button{min-height:2.2rem;border:1px solid var(--pg-line);border-radius:.45rem;background:transparent;color:var(--pg-dim);display:flex;align-items:center;justify-content:center;gap:.4rem;font-size:.64rem}
 .pg-ratio-field button.is-active{border-color:rgba(214,120,102,.45);background:rgba(197,68,89,.12);color:var(--pg-snow)}
+.pg-ratio-field button:disabled{cursor:not-allowed;opacity:.36}.pg-ratio-field legend em{font-style:normal;font-weight:500}
 .pg-ratio-glyph{height:.72rem;border:1px solid currentColor;border-radius:2px}.pg-ratio-glyph.ratio-1-1{aspect-ratio:1}.pg-ratio-glyph.ratio-4-3{aspect-ratio:4/3}.pg-ratio-glyph.ratio-3-4{aspect-ratio:3/4}.pg-ratio-glyph.ratio-16-9{aspect-ratio:16/9}
 .pg-voice-grid{display:grid;grid-template-columns:repeat(2,minmax(0,1fr));gap:.4rem}
 .pg-voice-option{min-width:0;min-height:3.1rem;padding:.5rem .6rem;border:1px solid var(--pg-line);border-radius:.55rem;background:rgba(229,231,235,.012);display:flex;align-items:center;gap:.5rem;cursor:pointer}
@@ -1278,6 +1279,48 @@ pub(super) const DASHBOARD_APP_JS: &str = r##"
       safeQuery('[data-playground-model]')?.selectedOptions?.[0]?.dataset.playgroundMode ||
       'chat';
 
+    const selectedPlaygroundImageConfig = (scope = document) => {
+      const option = safeQuery('[data-playground-model]', scope)?.selectedOptions?.[0];
+      if (!option || option.dataset.playgroundMode !== 'image') return null;
+      let sizes = {};
+      try {
+        const parsed = JSON.parse(option.dataset.imageSizes || '{}');
+        if (parsed && typeof parsed === 'object' && !Array.isArray(parsed)) sizes = parsed;
+      } catch (_) {}
+      const ratio = safeQuery('[data-playground-aspect-ratio][aria-pressed="true"]', scope)?.dataset.playgroundAspectRatio || '1:1';
+      return {
+        dimensionMode: option.dataset.imageDimensionMode || 'size',
+        ratio,
+        size: typeof sizes[ratio] === 'string' ? sizes[ratio] : '',
+        sizes
+      };
+    };
+
+    const syncPlaygroundImageSizes = () => {
+      const select = safeQuery('[data-playground-model]');
+      if (!select || select.selectedOptions[0]?.dataset.playgroundMode !== 'image') return;
+      const option = select.selectedOptions[0];
+      let sizes = {};
+      try {
+        const parsed = JSON.parse(option.dataset.imageSizes || '{}');
+        if (parsed && typeof parsed === 'object' && !Array.isArray(parsed)) sizes = parsed;
+      } catch (_) {}
+      const buttons = Array.from(document.querySelectorAll('[data-playground-aspect-ratio]'));
+      let selected = buttons.find((button) => button.getAttribute('aria-pressed') === 'true' && sizes[button.dataset.playgroundAspectRatio]);
+      if (!selected) selected = buttons.find((button) => sizes[button.dataset.playgroundAspectRatio]);
+      buttons.forEach((button) => {
+        const ratio = button.dataset.playgroundAspectRatio || '';
+        const size = typeof sizes[ratio] === 'string' ? sizes[ratio] : '';
+        button.disabled = !size;
+        button.classList.toggle('is-active', button === selected);
+        button.setAttribute('aria-pressed', String(button === selected));
+        button.title = size ? `${size.replace('x', '\u00d7')} for this model` : 'This aspect ratio is unavailable for this model';
+      });
+      const sizeLabel = safeQuery('[data-playground-image-size]');
+      const selectedSize = selected ? sizes[selected.dataset.playgroundAspectRatio] : '';
+      if (sizeLabel) sizeLabel.textContent = selectedSize ? selectedSize.replace('x', '\u00d7') : 'No compatible dimensions';
+    };
+
     const playgroundOptionsForMode = (mode) =>
       Array.from(safeQuery('[data-playground-model]')?.options || [])
         .filter((option) => option.dataset.playgroundMode === mode);
@@ -1332,6 +1375,7 @@ pub(super) const DASHBOARD_APP_JS: &str = r##"
       });
       const modelFact = safeQuery('[data-playground-fact="model"]');
       if (modelFact) modelFact.textContent = selected?.value || name;
+      syncPlaygroundImageSizes();
     };
 
     const syncPlaygroundInputs = () => {
@@ -1350,7 +1394,7 @@ pub(super) const DASHBOARD_APP_JS: &str = r##"
       const busy = Boolean(playgroundController);
       const imageButton = safeQuery('[data-playground-generate-image]');
       const speechButton = safeQuery('[data-playground-generate-speech]');
-      if (imageButton) imageButton.disabled = !imagePrompt?.value.trim() || busy;
+      if (imageButton) imageButton.disabled = !imagePrompt?.value.trim() || busy || !selectedPlaygroundImageConfig()?.size;
       if (speechButton) speechButton.disabled = !speechText?.value.trim() || busy;
     };
 
@@ -2165,8 +2209,24 @@ pub(super) const DASHBOARD_APP_JS: &str = r##"
       if (playgroundController) { announce('A request is already in progress.', true); return; }
       const controls = playgroundRequestControls(form);
       if (!controls) return;
-      const ratio = safeQuery('[data-playground-aspect-ratio][aria-pressed="true"]')?.dataset.playgroundAspectRatio || '1:1';
-      const size = { '1:1': '512x512', '4:3': '640x480', '3:4': '480x640', '16:9': '768x432' }[ratio] || '512x512';
+      const imageConfig = selectedPlaygroundImageConfig(form);
+      if (!imageConfig?.size) {
+        announce('The selected model does not publish compatible dimensions for this aspect ratio.', true);
+        return;
+      }
+      const { ratio, size } = imageConfig;
+      const [width, height] = size.split('x').map((value) => Number.parseInt(value, 10));
+      if (!Number.isInteger(width) || !Number.isInteger(height) || width <= 0 || height <= 0) {
+        announce('The selected model published invalid image dimensions.', true);
+        return;
+      }
+      const requestBody = { model: model.value, prompt: promptValue, n: 1, response_format: 'b64_json' };
+      if (imageConfig.dimensionMode === 'width-height') {
+        requestBody.width = width;
+        requestBody.height = height;
+      } else {
+        requestBody.size = size;
+      }
       const controller = new AbortController();
       playgroundController = controller;
       playgroundBusy(true);
@@ -2179,7 +2239,7 @@ pub(super) const DASHBOARD_APP_JS: &str = r##"
         setPlaygroundNetwork('matching', { mode: 'image', model: model.value });
         const response = await fetch('/v1/images/generations', {
           method: 'POST', credentials: 'same-origin', headers: playgroundHeaders(form, controls),
-          body: JSON.stringify({ model: model.value, prompt: promptValue, n: 1, size, response_format: 'b64_json' }),
+          body: JSON.stringify(requestBody),
           signal: controller.signal
         });
         if (!response.ok) throw new Error(await playgroundFailureMessage(response));
@@ -2196,7 +2256,7 @@ pub(super) const DASHBOARD_APP_JS: &str = r##"
         output.replaceChildren();
         const result = document.createElement('div');
         result.className = 'pg-image-result';
-        result.innerHTML = `<div class="pg-image-frame ratio-${ratio.replace(':', '-')}"><img class="pg-generated-image" alt="" width="${size.split('x')[0]}" height="${size.split('x')[1]}"></div><p class="pg-image-meta"></p><div class="pg-output-actions"><a class="pg-text-action" download></a><button class="pg-text-action" type="button" data-copy data-copy-value="">Copy prompt</button><button class="pg-text-action" type="button" data-playground-generate-image>Retry</button><button class="pg-text-action" type="button" data-playground-clear-image>Clear</button></div>`;
+        result.innerHTML = `<div class="pg-image-frame ratio-${ratio.replace(':', '-')}"><img class="pg-generated-image" alt="" width="${width}" height="${height}"></div><p class="pg-image-meta"></p><div class="pg-output-actions"><a class="pg-text-action" download></a><button class="pg-text-action" type="button" data-copy data-copy-value="">Copy prompt</button><button class="pg-text-action" type="button" data-playground-generate-image>Retry</button><button class="pg-text-action" type="button" data-playground-clear-image>Clear</button></div>`;
         const generated = safeQuery('img', result);
         generated.src = source;
         generated.alt = `Generated image: ${promptValue.slice(0, 180)}`;
@@ -2814,6 +2874,8 @@ pub(super) const DASHBOARD_APP_JS: &str = r##"
           button.classList.toggle('is-active', selected);
           button.setAttribute('aria-pressed', String(selected));
         });
+        syncPlaygroundImageSizes();
+        syncPlaygroundInputs();
         savePlaygroundDraft();
         return;
       }

--- a/crates/mayhem-gateway/tests/dashboard-browser-smoke.mjs
+++ b/crates/mayhem-gateway/tests/dashboard-browser-smoke.mjs
@@ -399,6 +399,7 @@ try {
   const selectedRatio = await page.locator('[data-playground-aspect-ratio][aria-pressed="true"]').getAttribute('data-playground-aspect-ratio');
   const expectedImageSize = imageSizes[selectedRatio];
   check(Boolean(expectedImageSize), 'Playground image dimensions', 'selects dimensions published by the signed model contract');
+  equal(expectedImageSize, '1024x1024', 'Playground image dimensions', 'uses the landing Playground proven square preset');
   check(expectedImageSize !== '512x512', 'Playground image dimensions', 'does not reuse the rejected 512 by 512 hardcoded size');
   equal(
     await page.locator('[data-playground-image-size]').innerText(),

--- a/crates/mayhem-gateway/tests/dashboard-browser-smoke.mjs
+++ b/crates/mayhem-gateway/tests/dashboard-browser-smoke.mjs
@@ -392,6 +392,29 @@ try {
   await page.keyboard.press('Escape');
   equal(await playgroundModelTrigger.getAttribute('aria-expanded'), 'false', 'Playground model picker', 'closes with Escape');
   check(await playgroundModelTrigger.evaluate((trigger) => trigger === document.activeElement), 'Playground model picker', 'returns focus to its trigger');
+
+  await page.getByRole('tab', { name: 'Image', exact: true }).click();
+  const imageOption = playgroundModel.locator('option:checked');
+  const imageSizes = JSON.parse((await imageOption.getAttribute('data-image-sizes')) || '{}');
+  const selectedRatio = await page.locator('[data-playground-aspect-ratio][aria-pressed="true"]').getAttribute('data-playground-aspect-ratio');
+  const expectedImageSize = imageSizes[selectedRatio];
+  check(Boolean(expectedImageSize), 'Playground image dimensions', 'selects dimensions published by the signed model contract');
+  check(expectedImageSize !== '512x512', 'Playground image dimensions', 'does not reuse the rejected 512 by 512 hardcoded size');
+  equal(
+    await page.locator('[data-playground-image-size]').innerText(),
+    expectedImageSize.replace('x', '\u00d7'),
+    'Playground image dimensions',
+    'shows the exact dimensions that will be requested',
+  );
+  await page.locator('[data-playground-image-prompt]').fill('A signed-dimension compatibility check.');
+  const imageRequestPromise = page.waitForRequest((request) => request.url().endsWith('/v1/images/generations') && request.method() === 'POST');
+  await page.locator('[data-playground-generate-image]').click();
+  const imageRequest = await imageRequestPromise;
+  const imageRequestBody = imageRequest.postDataJSON();
+  equal(imageRequestBody.size, expectedImageSize, 'Playground image dimensions', 'submits the selected model-compatible size');
+  await page.locator('.pg-generated-image').waitFor();
+  await page.getByRole('tab', { name: 'Text', exact: true }).click();
+
   await page.locator('.pg-advanced > summary').click();
   check(await rateOption.count() > 0, 'Playground price controls', 'offers a rate-priced fixture model');
   check(await fixedOption.count() > 0, 'Playground price controls', 'offers a fixed-only fixture model');


### PR DESCRIPTION
## Summary
- replace the Playground's hardcoded image dimensions with sizes derived from each selected model's signed endpoint contract
- prefer the landing Playground's proven Z-Image presets: 1024x1024, 1152x864, 864x1152, and 1344x768
- fall back to the nearest contract-valid dimensions and disable ratios the selected model cannot satisfy
- support both OpenAI `size` requests and contracts that require explicit `width`/`height`
- show the exact request dimensions in the UI before generation
- add Rust and Chromium regression coverage for models whose signed minimum rejects 512x512

## Root cause
The dashboard always submitted `512x512` for a square image. The live `tongyi/z-image-turbo` contract requires width and height to be at least 576 and multiples of 16, so gateway normalization correctly rejected the dashboard request. The landing Playground already avoided this by using a tested `1024x1024` square preset.

## Verification
- `cargo fmt --all -- --check`
- `cargo test -p mayhem-gateway --features dashboard-workbench dashboard` (49 unit + 12 integration tests)
- dashboard workbench smoke: 8,196 assertions
- Chromium dashboard smoke: 1,542 assertions, including a successful 1024x1024 contract-derived image request matching the landing Playground