### PR TITLE
Add lightweight GitHub update awareness to the dashboard

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2080,6 +2080,7 @@ dependencies = [
  "mayhem-bridge",
  "mayhem-enclave",
  "mayhem-proto",
+ "reqwest",
  "semver",
  "serde",
  "serde_json",

--- a/crates/mayhem-cli/src/main.rs
+++ b/crates/mayhem-cli/src/main.rs
@@ -29083,7 +29083,8 @@ async fn use_gateway(args: UseArgs) -> Result<()> {
     let state = match payment_directory {
         Some(directory) => state.with_payment_directory(directory),
         None => state,
-    };
+    }
+    .with_github_update_check_enabled();
     if let Some(config) = heartbeat_watcher {
         spawn_gateway_provider_heartbeat_watcher(state.clone(), config);
     }

--- a/crates/mayhem-gateway/Cargo.toml
+++ b/crates/mayhem-gateway/Cargo.toml
@@ -34,6 +34,7 @@ image = { version = "0.25", default-features = false, features = ["jpeg", "png"]
 jsonwebtoken = "9.3"
 mayhem-bridge = { path = "../mayhem-bridge" }
 mayhem-proto = { path = "../mayhem-proto" }
+reqwest = { version = "0.13", default-features = false, features = ["json", "rustls"] }
 semver = "1"
 serde = { version = "1", features = ["derive"] }
 serde_json = "1"

--- a/crates/mayhem-gateway/build.rs
+++ b/crates/mayhem-gateway/build.rs
@@ -1,0 +1,33 @@
+#![forbid(unsafe_code)]
+
+use std::{env, process::Command};
+
+fn main() {
+    println!("cargo:rerun-if-env-changed=MAYHEM_BUILD_GIT_SHA");
+    println!("cargo:rerun-if-changed=../../.git/HEAD");
+    println!("cargo:rerun-if-changed=../../.git/refs/heads");
+
+    let revision = env::var("MAYHEM_BUILD_GIT_SHA")
+        .ok()
+        .filter(|value| is_git_revision(value))
+        .or_else(git_head_revision)
+        .unwrap_or_else(|| "unknown".to_owned());
+    println!("cargo:rustc-env=MAYHEM_BUILD_GIT_SHA={revision}");
+}
+
+fn git_head_revision() -> Option<String> {
+    let output = Command::new("git")
+        .args(["rev-parse", "HEAD"])
+        .output()
+        .ok()?;
+    if !output.status.success() {
+        return None;
+    }
+    let revision = String::from_utf8(output.stdout).ok()?;
+    let revision = revision.trim();
+    is_git_revision(revision).then(|| revision.to_ascii_lowercase())
+}
+
+fn is_git_revision(value: &str) -> bool {
+    value.len() == 40 && value.bytes().all(|byte| byte.is_ascii_hexdigit())
+}

--- a/crates/mayhem-gateway/src/main.rs
+++ b/crates/mayhem-gateway/src/main.rs
@@ -18,7 +18,7 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
         );
         std::process::exit(2);
     }
-    let state = GatewayState::from_embedded_catalog();
+    let state = GatewayState::from_embedded_catalog().with_github_update_check_enabled();
     eprintln!(
         "mayhem-gateway listening on http://{} with development embedded catalog",
         args.bind

--- a/crates/mayhem-gateway/src/openai.rs
+++ b/crates/mayhem-gateway/src/openai.rs
@@ -100,6 +100,12 @@ use tower::limit::ConcurrencyLimitLayer;
 
 type SharedState = Arc<GatewayState>;
 
+mod github_update;
+use github_update::{
+    automatic_update_check_enabled, check_github_update, GithubUpdateCache, GithubUpdateCheckConfig,
+};
+pub use github_update::{GatewayGithubUpdate, GatewayGithubUpdateStatus};
+
 mod dashboard_ui;
 use dashboard_ui::{DASHBOARD_APP_CSS, DASHBOARD_APP_JS};
 
@@ -236,6 +242,8 @@ pub struct GatewayState {
     preferred_providers: Arc<Mutex<BTreeMap<String, Vec<String>>>>,
     access_control: Arc<GatewayAccessControl>,
     hidden_update_models: Arc<Vec<GatewayUpdateModelNotice>>,
+    github_update_status: Arc<Mutex<GatewayGithubUpdateStatus>>,
+    github_update_check_enabled: bool,
     epoch_seconds: u64,
     provider_heartbeat_ttl_millis: u64,
     ctx_bracket_schedule: Arc<CtxBracketSchedule>,
@@ -3034,6 +3042,8 @@ impl GatewayState {
             preferred_providers: Arc::new(Mutex::new(BTreeMap::new())),
             access_control: Arc::new(GatewayAccessControl::disabled()),
             hidden_update_models: Arc::new(Vec::new()),
+            github_update_status: Arc::new(Mutex::new(GatewayGithubUpdateStatus::disabled())),
+            github_update_check_enabled: false,
             epoch_seconds: DEFAULT_EPOCH_SECONDS,
             provider_heartbeat_ttl_millis: DEFAULT_PROVIDER_HEARTBEAT_TTL_MILLIS,
             ctx_bracket_schedule: Arc::new(default_ctx_bracket_schedule()),
@@ -3338,6 +3348,32 @@ impl GatewayState {
 
     pub fn update_notice(&self) -> Option<GatewayUpdateNotice> {
         gateway_update_notice(&self.models_snapshot(), &self.hidden_update_models)
+    }
+
+    pub fn with_github_update_check_enabled(mut self) -> Self {
+        self.github_update_check_enabled = true;
+        *self
+            .github_update_status
+            .lock_recover("GitHub update status") = GatewayGithubUpdateStatus::checking();
+        self
+    }
+
+    pub fn with_github_update_status(mut self, status: GatewayGithubUpdateStatus) -> Self {
+        self.github_update_check_enabled = false;
+        self.github_update_status = Arc::new(Mutex::new(status));
+        self
+    }
+
+    pub fn github_update_status(&self) -> GatewayGithubUpdateStatus {
+        self.github_update_status
+            .lock_recover("GitHub update status")
+            .clone()
+    }
+
+    fn replace_github_update_status(&self, status: GatewayGithubUpdateStatus) {
+        *self
+            .github_update_status
+            .lock_recover("GitHub update status") = status;
     }
 
     pub fn with_failover_policy(mut self, policy: GatewayFailoverPolicyConfig) -> Self {
@@ -3784,8 +3820,25 @@ pub async fn serve(bind: SocketAddr, mut state: GatewayState) -> std::io::Result
         GatewayMediaLimits::from_env()
             .map_err(|err| io::Error::new(io::ErrorKind::InvalidInput, err))?,
     );
+    if state.github_update_check_enabled && automatic_update_check_enabled() {
+        spawn_github_update_watcher(state.clone());
+    } else if state.github_update_check_enabled {
+        state.replace_github_update_status(GatewayGithubUpdateStatus::disabled());
+    }
     let listener = TcpListener::bind(bind).await?;
     axum::serve(listener, openai_router(state)).await
+}
+
+fn spawn_github_update_watcher(state: GatewayState) {
+    tokio::spawn(async move {
+        let config = GithubUpdateCheckConfig::from_env();
+        let mut cache = GithubUpdateCache::default();
+        loop {
+            let status = check_github_update(&config, &mut cache, now_secs()).await;
+            state.replace_github_update_status(status);
+            tokio::time::sleep(config.interval).await;
+        }
+    });
 }
 
 pub fn gateway_bind_is_loopback(bind: SocketAddr) -> bool {
@@ -6747,6 +6800,7 @@ async fn mayhem_status(State(state): State<SharedState>, headers: HeaderMap) -> 
         "receipts": state.receipt_count(),
         "probes": state.probes.lock_recover("probe store").len(),
         "update_notice": update_notice,
+        "github_update": state.github_update_status(),
         "access": state.access_summary(),
     }))
     .into_response()

--- a/crates/mayhem-gateway/src/openai/dashboard_pages.rs
+++ b/crates/mayhem-gateway/src/openai/dashboard_pages.rs
@@ -100,6 +100,7 @@ struct DashboardData {
     payment_directory: Option<Value>,
     access: Value,
     update_notice: Option<GatewayUpdateNotice>,
+    github_update: GatewayGithubUpdateStatus,
     earnings: GatewayProviderEarningsSnapshot,
     local_provider_id: Option<String>,
     rail: String,
@@ -128,6 +129,7 @@ impl DashboardData {
             payment_directory: state.payment_directory(),
             access: state.access_summary(),
             update_notice: state.update_notice(),
+            github_update: state.github_update_status(),
             earnings: state.provider_earnings_snapshot(),
             local_provider_id: state.local_provider_id().map(str::to_owned),
             rail: state.receipt_config.rail.clone(),
@@ -1229,6 +1231,15 @@ fn shell_impl(
         format!("{status_freshness}{content}")
     };
     let content = keyboard_accessible_table_regions(&content);
+    let update_presentation = dashboard_update_presentation(data);
+    let topbar_update = update_presentation
+        .as_ref()
+        .map(dashboard_topbar_update)
+        .unwrap_or_default();
+    let settings_update_badge = update_presentation
+        .as_ref()
+        .map(dashboard_settings_update_badge)
+        .unwrap_or_default();
     dashboard_app_shell(DashboardShell {
         page,
         eyebrow,
@@ -1237,11 +1248,92 @@ fn shell_impl(
         status,
         status_tone: tone,
         actions,
+        topbar_update: &topbar_update,
+        settings_update_badge: &settings_update_badge,
         content: &content,
         footer: "Controls and evidence belong to this gateway process.",
         expires_in_seconds: expires,
         wide,
     })
+}
+
+struct DashboardUpdatePresentation {
+    id: String,
+    label: String,
+    tone: &'static str,
+    required: bool,
+}
+
+fn dashboard_update_presentation(data: &DashboardData) -> Option<DashboardUpdatePresentation> {
+    if let Some(notice) = data
+        .update_notice
+        .as_ref()
+        .filter(|notice| notice.level == "required")
+    {
+        return Some(DashboardUpdatePresentation {
+            id: format!("catalog-required:{}", notice.required_min_app_version),
+            label: "Update required".to_owned(),
+            tone: "danger",
+            required: true,
+        });
+    }
+    if let Some(update) = data.github_update.update.as_ref() {
+        let label = match (update.installable, update.available_version.as_deref()) {
+            (true, Some(version)) => format!("{} available", version.trim_start_matches('v')),
+            (false, Some(_)) => "New version on GitHub".to_owned(),
+            _ => "Source update available".to_owned(),
+        };
+        let identifier = update
+            .available_version
+            .as_deref()
+            .or(update.available_revision.as_deref())
+            .unwrap_or("source");
+        return Some(DashboardUpdatePresentation {
+            id: format!("github:{}:{identifier}", update.kind),
+            label,
+            tone: "info",
+            required: false,
+        });
+    }
+    data.update_notice
+        .as_ref()
+        .map(|notice| DashboardUpdatePresentation {
+            id: format!("catalog-available:{}", notice.required_min_app_version),
+            label: "Update available".to_owned(),
+            tone: "info",
+            required: false,
+        })
+}
+
+fn dashboard_topbar_update(update: &DashboardUpdatePresentation) -> String {
+    let dismiss = if update.required {
+        String::new()
+    } else {
+        format!(
+            r#"<button type="button" data-update-dismiss aria-label="Dismiss {} notice"><span aria-hidden="true">×</span></button>"#,
+            html_escape(&update.label)
+        )
+    };
+    format!(
+        r#"<div class="topbar-update-notice {} js-only" data-update-notice data-update-id="{}"><a href="/mayhem/dashboard/settings" aria-label="{}; review in Settings"><span class="topbar-update-icon" aria-hidden="true">↑</span><span class="topbar-update-label">{}</span><span class="topbar-update-label-mobile">Update</span></a>{dismiss}</div>"#,
+        update.tone,
+        html_escape(&update.id),
+        html_escape(&update.label),
+        html_escape(&update.label),
+    )
+}
+
+fn dashboard_settings_update_badge(update: &DashboardUpdatePresentation) -> String {
+    format!(
+        r#"<span class="nav-update-badge {}"><span aria-hidden="true"></span><span class="nav-update-text">{}</span><span class="sr-only">: {}</span></span>"#,
+        update.tone,
+        if update.required {
+            "Required"
+        } else {
+            "Update"
+        },
+        html_escape(&update.label),
+    )
 }
 
 fn keyboard_accessible_table_regions(content: &str) -> String {
@@ -1281,22 +1373,17 @@ fn keyboard_accessible_table_regions(content: &str) -> String {
 }
 
 fn global_update_attention(data: &DashboardData) -> String {
-    let Some(notice) = data.update_notice.as_ref() else {
+    let Some(notice) = data
+        .update_notice
+        .as_ref()
+        .filter(|notice| notice.level == "required")
+    else {
         return String::new();
     };
-    let tone = if notice.level == "required" {
-        "danger"
-    } else {
-        "warn"
-    };
     attention(
-        tone,
+        "danger",
         "!",
-        if notice.level == "required" {
-            "Update required"
-        } else {
-            "Update available"
-        },
+        "Update required",
         &format!(
             "Installed {}. A newer app version (minimum {}) is required for {}.",
             notice.installed_app_version,
@@ -4565,32 +4652,34 @@ fn help_page(data: &DashboardData, expires: u64) -> String {
 }
 
 fn settings_page(data: &DashboardData, expires: u64) -> String {
-    let (version_status, version_tone) = match data.update_notice.as_ref() {
-        Some(notice) if notice.level == "required" => ("Update required", "danger"),
-        Some(_) => ("Update available", "warn"),
-        None => ("Up to date", "good"),
+    let github_update = data.github_update.update.as_ref();
+    let (version_status, version_tone) = match (data.update_notice.as_ref(), github_update) {
+        (Some(notice), _) if notice.level == "required" => ("Update required", "danger"),
+        (_, Some(_)) | (Some(_), _) => ("Update available", ""),
+        _ if data.github_update.state == "current" => ("Up to date", "good"),
+        _ if data.github_update.state == "checking" => ("Checking GitHub", ""),
+        _ => ("Installed", ""),
     };
-    let update = data
-        .update_notice
-        .as_ref()
-        .map(|notice| {
+    let update = match (data.update_notice.as_ref(), github_update) {
+        (Some(notice), _) if notice.level == "required" => {
             format!(
                 "Installed {} / catalog minimum {} / {} affected",
                 notice.installed_app_version,
                 notice.required_min_app_version,
                 notice.affected_model_count
             )
-        })
-        .unwrap_or_else(|| {
-            format!(
-                "Mayhem {} · compatible with the current catalog",
-                installed_app_version()
-            )
-        });
-    let update_resolution = if data.update_notice.is_some() {
-        r##"<div class="field"><span class="field-label">1. Verify and stage on the gateway host</span><pre class="code-block"><code id="mayhem-update-stage-command">mayhem update</code><button class="quiet-button copy-corner js-only" type="button" data-copy data-copy-target="#mayhem-update-stage-command" aria-label="Copy Mayhem update staging command"><span data-copy-label>Copy</span></button></pre><p class="result-summary">Downloads and verifies the release, then stages it. This does not replace the installed binary.</p></div><div class="field-gap" aria-hidden="true"></div><div class="field"><span class="field-label">2. Apply the staged update</span><pre class="code-block"><code id="mayhem-update-apply-command">mayhem update --apply-staged</code><button class="quiet-button copy-corner js-only" type="button" data-copy data-copy-target="#mayhem-update-apply-command" aria-label="Copy Mayhem staged-update apply command"><span data-copy-label>Copy</span></button></pre><p class="result-summary">Run after the required staging delay. Applying replaces the host binary and runs its health check, but it does not restart an already-running gateway service; restart that service, then reload this page.</p></div>"##
-    } else {
-        ""
+        }
+        (_, Some(update)) => update.message.clone(),
+        _ => format!(
+            "Mayhem {} · {}",
+            data.github_update.installed_version, data.github_update.message
+        ),
+    };
+    let update_resolution = match github_update {
+        Some(update) if update.installable => signed_release_update_resolution(update),
+        Some(update) => source_update_resolution(update),
+        None if data.update_notice.is_some() => signed_update_commands(None),
+        None => String::new(),
     };
     let content = format!(
         r##"<section class="dashboard-layout"><div class="stack"><section class="panel"><header class="panel-head"><div class="panel-title"><h2>Display and attention</h2><p>Preferences are stored in this browser profile.</p></div></header><noscript><div class="panel-body"><p class="notice warn">Display preferences require JavaScript. Gateway session and version facts remain available.</p></div></noscript><div class="settings-list"><div class="settings-row"><div class="settings-copy"><strong>Hide money amounts</strong><span>Replaces monetary text semantically and visually on dashboard pages.</span></div><button class="settings-control soft-button js-only" type="button" data-preference="amounts" role="switch" aria-label="Hide money amounts" aria-checked="false"><span class="switch-track" aria-hidden="true"></span><span data-preference-label>Off</span></button></div><div class="settings-row"><div class="settings-copy"><strong>Reduce motion</strong><span>Disables transitions and animated feedback while preserving state.</span></div><button class="settings-control soft-button js-only" type="button" data-preference="motion" role="switch" aria-label="Reduce motion" aria-checked="false"><span class="switch-track" aria-hidden="true"></span><span data-preference-label>Off</span></button></div><div class="settings-row"><div class="settings-copy"><strong>Compact density</strong><span>Reduces spacing for professional monitoring without hiding explanations.</span></div><button class="settings-control soft-button js-only" type="button" data-preference="density" role="switch" aria-label="Compact density" aria-checked="false"><span class="switch-track" aria-hidden="true"></span><span data-preference-label>Off</span></button></div><div class="settings-row"><div class="settings-copy"><strong>Playground conversation history</strong><span>Prompts and responses are stored only in this browser profile. Credentials are never saved.</span></div><button class="settings-control quiet-button js-only" type="button" data-clear-playground-history>Clear history</button></div></div><footer class="panel-footer"><button class="quiet-button js-only" type="button" data-clear-preferences>Reset preferences</button></footer></section><details class="panel disclosure-panel"><summary><span>Local launch diagnostics</span><span class="status-badge"><span data-local-event-count>0</span>&nbsp;events</span></summary><div class="panel-body"><p class="notice">Optional debugging log for launch issues. Events stay in this browser and never include prompts, responses, credentials, or money amounts.</p><div class="inline-actions section-gap"><button class="soft-button js-only" type="button" data-export-local-events>Export JSON</button><button class="quiet-button js-only" type="button" data-clear-local-events>Clear diagnostics</button></div></div></details></div><aside class="stack"><section class="panel"><header class="panel-head"><div class="panel-title"><h2>Gateway session</h2><p>Access and runtime facts for this gateway</p></div></header><div class="panel-body"><div class="fact-grid"><div class="fact"><span>Authentication</span><strong>{}</strong></div><div class="fact"><span>Active tokens</span><strong>{}</strong></div><div class="fact"><span>Receipt rail</span><strong>{}</strong></div><div class="fact"><span>Provider identity</span><strong>{}</strong></div></div></div></section><section class="panel"><header class="panel-head"><div class="panel-title"><h2>Version</h2><p>From the installed app and catalog requirements</p></div></header><div class="panel-body"><p class="notice {}">{}</p>{update_resolution}</div></section></aside></section>"##,
@@ -4620,6 +4709,46 @@ fn settings_page(data: &DashboardData, expires: u64) -> String {
         "",
         &content,
     )
+}
+
+fn signed_release_update_resolution(update: &GatewayGithubUpdate) -> String {
+    signed_update_commands(update.release_url.as_deref())
+}
+
+fn signed_update_commands(release_url: Option<&str>) -> String {
+    let release_link = safe_github_link(release_url)
+        .map(|url| {
+            format!(
+                r#"<a class="quiet-button" href="{}" target="_blank" rel="noopener noreferrer">View release notes <span aria-hidden="true">↗</span></a>"#,
+                html_escape(url)
+            )
+        })
+        .unwrap_or_default();
+    format!(
+        r##"<div class="version-guidance"><p><strong>Agent-guided update recommended.</strong> Ask your agent to guide these steps and review every command before running it.</p>{release_link}</div><div class="field"><span class="field-label">1. Verify and stage on the gateway host</span><pre class="code-block"><code id="mayhem-update-stage-command">mayhem update</code><button class="quiet-button copy-corner js-only" type="button" data-copy data-copy-target="#mayhem-update-stage-command" aria-label="Copy Mayhem update staging command"><span data-copy-label>Copy</span></button></pre><p class="result-summary">Downloads and verifies the signed release, then stages it. This does not replace the installed binary.</p></div><div class="field-gap" aria-hidden="true"></div><div class="field"><span class="field-label">2. Apply the staged update</span><pre class="code-block"><code id="mayhem-update-apply-command">mayhem update --apply-staged</code><button class="quiet-button copy-corner js-only" type="button" data-copy data-copy-target="#mayhem-update-apply-command" aria-label="Copy Mayhem staged-update apply command"><span data-copy-label>Copy</span></button></pre><p class="result-summary">Run after the required staging delay. Applying replaces the host binary and runs its health check, but it does not restart an already-running gateway service; restart that service, then reload this page.</p></div>"##
+    )
+}
+
+fn source_update_resolution(update: &GatewayGithubUpdate) -> String {
+    let url = update
+        .release_url
+        .as_deref()
+        .or(update.compare_url.as_deref());
+    let link = safe_github_link(url)
+        .map(|url| {
+            format!(
+                r#"<a class="soft-button" href="{}" target="_blank" rel="noopener noreferrer">View changes on GitHub <span aria-hidden="true">↗</span></a>"#,
+                html_escape(url)
+            )
+        })
+        .unwrap_or_default();
+    format!(
+        r#"<div class="version-guidance source"><p><strong>Source update only.</strong> No signed executable update is available for this system yet. Update from your source checkout using its existing build process.</p><p>Agent-guided updating is recommended; review every command before running it. When signed executables are published, this panel will switch automatically to the verified updater.</p>{link}</div>"#
+    )
+}
+
+fn safe_github_link(value: Option<&str>) -> Option<&str> {
+    value.filter(|url| url.starts_with("https://github.com/"))
 }
 
 #[derive(Clone, Debug)]
@@ -6612,6 +6741,78 @@ mod tests {
         assert!(html.contains("data-copy-target=\"#mayhem-update-apply-command\""));
         assert!(html.contains("does not replace the installed binary"));
         assert!(html.contains("does not restart an already-running gateway service"));
+    }
+
+    #[test]
+    fn source_update_is_lightweight_and_never_claims_a_binary_is_available() {
+        let state = GatewayState::from_models(Vec::new());
+        let mut data = DashboardData::from_state(&state);
+        let update = GatewayGithubUpdate {
+            kind: "source".to_owned(),
+            installed_version: "0.2.0".to_owned(),
+            available_version: None,
+            installed_revision: Some("1".repeat(40)),
+            available_revision: Some("2".repeat(40)),
+            release_url: None,
+            compare_url: Some(
+                "https://github.com/Trac-Systems/openmayhem/compare/source...main".to_owned(),
+            ),
+            published_at: None,
+            installable: false,
+            message: "3 newer source changes are available on GitHub.".to_owned(),
+        };
+        data.github_update = GatewayGithubUpdateStatus {
+            state: "available".to_owned(),
+            installed_version: "0.2.0".to_owned(),
+            installed_revision: update.installed_revision.clone(),
+            checked_at_seconds: Some(42),
+            message: update.message.clone(),
+            update: Some(update),
+        };
+
+        let html = settings_page(&data, 60);
+        assert!(html.contains("Source update only."));
+        assert!(html.contains("View changes on GitHub"));
+        assert!(html.contains("data-update-notice"));
+        assert!(html.contains("nav-update-badge info"));
+        assert!(!html.contains("mayhem-update-stage-command"));
+        assert!(!html.contains("attention-card danger"));
+    }
+
+    #[test]
+    fn signed_release_switches_to_the_verified_updater_guidance() {
+        let state = GatewayState::from_models(Vec::new());
+        let mut data = DashboardData::from_state(&state);
+        let update = GatewayGithubUpdate {
+            kind: "release".to_owned(),
+            installed_version: "0.2.0".to_owned(),
+            available_version: Some("0.3.0".to_owned()),
+            installed_revision: Some("1".repeat(40)),
+            available_revision: None,
+            release_url: Some(
+                "https://github.com/Trac-Systems/openmayhem/releases/tag/0.3.0".to_owned(),
+            ),
+            compare_url: None,
+            published_at: Some("2026-07-18T12:00:00Z".to_owned()),
+            installable: true,
+            message: "Mayhem 0.3.0 is available as a signed update for this system.".to_owned(),
+        };
+        data.github_update = GatewayGithubUpdateStatus {
+            state: "available".to_owned(),
+            installed_version: "0.2.0".to_owned(),
+            installed_revision: update.installed_revision.clone(),
+            checked_at_seconds: Some(42),
+            message: update.message.clone(),
+            update: Some(update),
+        };
+
+        let html = settings_page(&data, 60);
+        assert!(html.contains("0.3.0 available"));
+        assert!(html.contains("Agent-guided update recommended."));
+        assert!(html.contains("View release notes"));
+        assert!(html.contains("mayhem-update-stage-command"));
+        assert!(html.contains("mayhem-update-apply-command"));
+        assert!(!html.contains("Source update only."));
     }
 
     #[test]

--- a/crates/mayhem-gateway/src/openai/dashboard_ui.rs
+++ b/crates/mayhem-gateway/src/openai/dashboard_ui.rs
@@ -100,6 +100,8 @@ pub(super) struct DashboardShell<'a> {
     pub status: &'a str,
     pub status_tone: &'a str,
     pub actions: &'a str,
+    pub topbar_update: &'a str,
+    pub settings_update_badge: &'a str,
     pub content: &'a str,
     pub footer: &'a str,
     pub expires_in_seconds: u64,
@@ -170,11 +172,11 @@ pub(super) fn dashboard_app_shell(shell: DashboardShell<'_>) -> String {
 <div class="app-shell">
   <aside class="app-sidebar" id="app-navigation" aria-label="Mayhem navigation">
     <a class="app-brand" href="/mayhem/dashboard" aria-label="Mayhem Home"><span class="app-brand-mark" aria-hidden="true">M</span><span class="app-brand-text">MAY<span class="hem">HEM</span></span></a>
-    <nav class="app-nav" aria-label="Primary"><span class="app-nav-label">Workspace</span>{navigation}<details class="advanced-nav"{advanced_open}><summary><span class="nav-icon" aria-hidden="true">&#8943;</span><span class="nav-text">Advanced</span></summary><div class="advanced-nav-items">{advanced_navigation}</div></details><span class="app-nav-label">System</span><a href="/mayhem/dashboard/help" aria-label="Help"{help_current}><span class="nav-icon">{help_icon}</span><span class="nav-text">Help</span></a><a href="/mayhem/dashboard/settings" aria-label="Settings"{settings_current}><span class="nav-icon">{settings_icon}</span><span class="nav-text">Settings</span></a></nav>
+    <nav class="app-nav" aria-label="Primary"><span class="app-nav-label">Workspace</span>{navigation}<details class="advanced-nav"{advanced_open}><summary><span class="nav-icon" aria-hidden="true">&#8943;</span><span class="nav-text">Advanced</span></summary><div class="advanced-nav-items">{advanced_navigation}</div></details><span class="app-nav-label">System</span><a href="/mayhem/dashboard/help" aria-label="Help"{help_current}><span class="nav-icon">{help_icon}</span><span class="nav-text">Help</span></a><a href="/mayhem/dashboard/settings" aria-label="Settings"{settings_current}><span class="nav-icon">{settings_icon}</span><span class="nav-text">Settings</span>{settings_update_badge}</a></nav>
   </aside>
   <button class="nav-scrim js-only" type="button" data-nav-close aria-label="Close navigation"></button>
   <div class="app-frame">
-    <header class="app-topbar"><div class="topbar-context"><button class="icon-button mobile-menu-button js-only" type="button" data-nav-toggle aria-label="Open navigation" aria-controls="app-navigation" aria-expanded="false"><span aria-hidden="true">&#9776;</span></button><button class="icon-button sidebar-collapse-button js-only" type="button" data-sidebar-toggle aria-label="Collapse navigation" aria-controls="app-navigation" aria-expanded="true"><span aria-hidden="true">&#8592;</span></button><strong>{page_label}</strong><span class="topbar-status"><span class="state-indicator {status_tone}" aria-hidden="true"></span><span data-page-status-text>{status}</span></span></div><div class="topbar-actions">{amount_control}</div></header>
+    <header class="app-topbar"><div class="topbar-context"><button class="icon-button mobile-menu-button js-only" type="button" data-nav-toggle aria-label="Open navigation" aria-controls="app-navigation" aria-expanded="false"><span aria-hidden="true">&#9776;</span></button><button class="icon-button sidebar-collapse-button js-only" type="button" data-sidebar-toggle aria-label="Collapse navigation" aria-controls="app-navigation" aria-expanded="true"><span aria-hidden="true">&#8592;</span></button><strong>{page_label}</strong><span class="topbar-status"><span class="state-indicator {status_tone}" aria-hidden="true"></span><span data-page-status-text>{status}</span></span></div><div class="topbar-actions">{topbar_update}{amount_control}</div></header>
     <main class="app-main{wide_class}{page_class}" id="main-content" tabindex="-1"><header class="page-head"><div><p class="page-eyebrow">{eyebrow}</p><h1>{heading}</h1><p class="page-summary">{summary}</p></div><div class="page-head-actions">{actions}</div></header>{content}</main>
     <footer class="app-footer"><div class="app-footer-inner{wide_class_footer}"><span>{footer}</span><span class="mono" data-session-seconds="{expires}" data-session-status>Browser session active</span></div></footer>
   </div>
@@ -186,9 +188,11 @@ pub(super) fn dashboard_app_shell(shell: DashboardShell<'_>) -> String {
         advanced_open = if advanced_open { " open" } else { "" },
         help_current = help_current,
         settings_current = settings_current,
+        settings_update_badge = shell.settings_update_badge,
         status_tone = status_tone,
         status = html_escape(shell.status),
         amount_control = amount_control,
+        topbar_update = shell.topbar_update,
         page_label = shell.page.label(),
         help_icon = DashboardAppPage::Help.icon(),
         settings_icon = DashboardAppPage::Settings.icon(),
@@ -288,7 +292,7 @@ a,button{-webkit-tap-highlight-color:transparent}
 .app-brand-mark{width:34px;height:34px;border-radius:11px;display:grid;place-items:center;background:linear-gradient(145deg,var(--app-accent),#b83c61);box-shadow:0 8px 24px rgba(255,107,122,.24);font-size:13px}
 .app-nav{display:grid;gap:4px}
 .app-nav-label{margin:11px 10px 5px;color:var(--app-text-muted);font-size:12px;letter-spacing:.1em;text-transform:uppercase}
-.app-nav a{min-height:44px;display:flex;align-items:center;gap:11px;padding:10px 12px;border:1px solid transparent;border-radius:12px;color:var(--app-text-soft);text-decoration:none;font-weight:600}
+.app-nav a{position:relative;min-height:44px;display:flex;align-items:center;gap:11px;padding:10px 12px;border:1px solid transparent;border-radius:12px;color:var(--app-text-soft);text-decoration:none;font-weight:600}
 .app-nav a:hover{background:var(--app-panel);color:var(--app-text)}
 .app-nav a[aria-current="page"]{background:linear-gradient(110deg,rgba(255,107,122,.15),rgba(255,107,122,.04));border-color:rgba(255,107,122,.25);color:var(--app-text)}
 .advanced-nav{margin-top:3px}
@@ -300,6 +304,9 @@ a,button{-webkit-tap-highlight-color:transparent}
 .nav-icon{width:20px;height:20px;display:grid;place-items:center;color:var(--app-text-muted)}
 .nav-icon svg{width:19px;height:19px;fill:none;stroke:currentColor;stroke-width:1.8;stroke-linecap:round;stroke-linejoin:round}
 .app-nav a[aria-current="page"] .nav-icon{color:var(--app-accent-strong)}
+.nav-update-badge{margin-left:auto;min-height:20px;padding:2px 7px;border:1px solid rgba(110,168,255,.28);border-radius:999px;background:rgba(110,168,255,.09);color:var(--app-info);display:inline-flex;align-items:center;gap:5px;font-size:10px;font-weight:800;line-height:1}
+.nav-update-badge>span:first-child{width:6px;height:6px;border-radius:999px;background:currentColor;box-shadow:0 0 0 3px rgba(110,168,255,.08)}
+.nav-update-badge.danger{border-color:rgba(255,84,73,.3);background:rgba(255,84,73,.09);color:var(--app-danger)}
 .state-indicator{width:9px;height:9px;border-radius:999px;background:var(--app-text-muted);box-shadow:0 0 0 4px rgba(126,135,148,.1)}
 .state-indicator.good{background:var(--app-good);box-shadow:0 0 0 4px rgba(88,214,168,.1)}
 .state-indicator.warn{background:var(--app-warn);box-shadow:0 0 0 4px rgba(245,184,92,.1)}
@@ -311,6 +318,17 @@ a,button{-webkit-tap-highlight-color:transparent}
 .topbar-context strong{white-space:nowrap;overflow:hidden;text-overflow:ellipsis}
 .topbar-status{display:inline-flex;align-items:center;gap:8px;color:var(--app-text-soft);font-size:13px}
 .topbar-actions{display:flex;align-items:center;gap:8px}
+html.js-ready .topbar-update-notice.js-only:not([hidden]){display:flex!important}
+.topbar-update-notice{min-height:34px;border:1px solid rgba(110,168,255,.28);border-radius:10px;background:rgba(110,168,255,.07);align-items:stretch;color:var(--app-info);overflow:hidden}
+.topbar-update-notice.danger{border-color:rgba(255,84,73,.3);background:rgba(255,84,73,.08);color:var(--app-danger)}
+.topbar-update-notice>a{min-height:32px;padding:5px 9px;display:inline-flex;align-items:center;gap:6px;color:inherit;text-decoration:none;font-size:11px;font-weight:800;white-space:nowrap}
+.topbar-update-notice>a:hover{background:rgba(110,168,255,.08)}
+.topbar-update-notice.danger>a:hover{background:rgba(255,84,73,.08)}
+.topbar-update-icon{width:18px;height:18px;border-radius:6px;background:rgba(110,168,255,.12);display:grid;place-items:center;font-size:12px}
+.topbar-update-notice.danger .topbar-update-icon{background:rgba(255,84,73,.12)}
+.topbar-update-notice>button{width:29px;min-height:32px;padding:0;border:0;border-left:1px solid currentColor;background:transparent;color:inherit;opacity:.66;display:grid;place-items:center;font-size:15px}
+.topbar-update-notice>button:hover{opacity:1;background:rgba(110,168,255,.08)}
+.topbar-update-label-mobile{display:none}
 .icon-button,.soft-button,.primary-button,.quiet-button{min-height:44px;border-radius:12px;display:inline-flex;align-items:center;justify-content:center;gap:8px;padding:9px 13px;text-decoration:none;font-weight:700;transition:transform var(--app-fast) ease,background var(--app-fast) ease,border-color var(--app-fast) ease}
 .button-icon{width:18px;height:18px;display:grid;place-items:center}
 .button-icon svg{width:18px;height:18px;fill:none;stroke:currentColor;stroke-width:1.7;stroke-linecap:round;stroke-linejoin:round}
@@ -539,6 +557,10 @@ th[aria-sort="descending"] .table-sort-button::after{content:"↓";opacity:1;col
 .notice.good{border-color:rgba(88,214,168,.28);background:rgba(88,214,168,.06)}
 .notice.warn{border-color:rgba(245,184,92,.3);background:rgba(245,184,92,.07)}
 .notice.danger{border-color:rgba(255,84,73,.3);background:rgba(255,84,73,.07)}
+.version-guidance{margin:14px 0;padding:13px 14px;border:1px solid rgba(110,168,255,.22);border-radius:12px;background:rgba(110,168,255,.045);display:grid;gap:10px}
+.version-guidance.source{border-style:dashed}
+.version-guidance p{margin:0;color:var(--app-text-muted);font-size:12px;line-height:1.55}.version-guidance p strong{color:var(--app-text)}
+.version-guidance>a{justify-self:start}
 .code-block{position:relative;min-height:62px;margin:0;padding:20px 72px 20px 15px;border:1px solid var(--app-border);border-radius:13px;background:#0b0d10;color:#cdd3db;white-space:pre-wrap;overflow-wrap:anywhere;font:12px/1.58 ui-monospace,SFMono-Regular,Menlo,monospace}
 .code-block .copy-corner{position:absolute;right:8px;top:8px}
 .connect-ready{margin-bottom:24px;padding:17px 18px;border:1px solid var(--app-border);border-radius:16px;background:linear-gradient(120deg,rgba(88,214,168,.07),rgba(255,255,255,.015) 58%);display:grid;grid-template-columns:auto minmax(0,1fr) auto;align-items:center;gap:14px}
@@ -1001,6 +1023,9 @@ body.session-expired-visible .toast-region{bottom:max(112px,calc(env(safe-area-i
   html.sidebar-collapsed .app-brand{justify-content:center;padding-inline:0}
   html.sidebar-collapsed .app-brand-text,html.sidebar-collapsed .app-nav-label,html.sidebar-collapsed .app-nav .nav-text,html.sidebar-collapsed .advanced-nav-items{display:none}
   html.sidebar-collapsed .app-nav a,html.sidebar-collapsed .advanced-nav>summary{justify-content:center;padding-inline:10px}
+  html.sidebar-collapsed .nav-update-badge{position:absolute;right:5px;top:5px;width:7px;min-width:7px;height:7px;min-height:7px;padding:0;border:0;background:var(--app-info)}
+  html.sidebar-collapsed .nav-update-badge.danger{background:var(--app-danger)}
+  html.sidebar-collapsed .nav-update-badge>span{display:none}
   html.sidebar-collapsed .sidebar-collapse-button span{transform:rotate(180deg)}
 }
 
@@ -1054,6 +1079,7 @@ body.session-expired-visible .toast-region{bottom:max(112px,calc(env(safe-area-i
 }
 
 @media(max-width:520px){
+  .topbar-update-label{display:none}.topbar-update-label-mobile{display:inline}
   .topbar-actions .soft-button .button-label{display:none}
   .metric-grid{grid-template-columns:1fr}
   .metric-grid--three{grid-template-columns:1fr}
@@ -1191,6 +1217,21 @@ pub(super) const DASHBOARD_APP_JS: &str = r##"
       if (!selector) return null;
       try { return scope.querySelector(selector); } catch (_) { return null; }
     };
+
+    document.querySelectorAll('[data-update-notice]').forEach((notice) => {
+      const id = String(notice.dataset.updateId || '').trim();
+      if (!id) return;
+      const key = `mayhem.dashboard.dismissedUpdate.${id}`;
+      if (storage.get(key) === '1') {
+        notice.hidden = true;
+        return;
+      }
+      safeQuery('[data-update-dismiss]', notice)?.addEventListener('click', () => {
+        storage.set(key, '1');
+        notice.hidden = true;
+        announce('Update notice dismissed. The update indicator remains in Settings.', false, false);
+      });
+    });
 
     const readLocalProductEvents = () => {
       const stored = storage.get(localProductEventsKey);

--- a/crates/mayhem-gateway/src/openai/dashboard_workbench.rs
+++ b/crates/mayhem-gateway/src/openai/dashboard_workbench.rs
@@ -45,18 +45,22 @@ enum WorkbenchScenario {
     Loading,
     Failure,
     Offline,
+    SourceUpdate,
+    SignedUpdate,
     UpdateRequired,
     Scale,
 }
 
 impl WorkbenchScenario {
-    const ALL: [Self; 8] = [
+    const ALL: [Self; 10] = [
         Self::Showcase,
         Self::AuthRequired,
         Self::Empty,
         Self::Loading,
         Self::Failure,
         Self::Offline,
+        Self::SourceUpdate,
+        Self::SignedUpdate,
         Self::UpdateRequired,
         Self::Scale,
     ];
@@ -69,6 +73,8 @@ impl WorkbenchScenario {
             Self::Loading => "loading",
             Self::Failure => "failure",
             Self::Offline => "offline",
+            Self::SourceUpdate => "source-update",
+            Self::SignedUpdate => "signed-update",
             Self::UpdateRequired => "update-required",
             Self::Scale => "scale",
         }
@@ -82,6 +88,8 @@ impl WorkbenchScenario {
             Self::Loading => "Provider loading",
             Self::Failure => "Provider failure",
             Self::Offline => "Routes offline",
+            Self::SourceUpdate => "Source update",
+            Self::SignedUpdate => "Signed update",
             Self::UpdateRequired => "Update required",
             Self::Scale => "Scale and overflow",
         }
@@ -95,6 +103,8 @@ impl WorkbenchScenario {
             Self::Loading => "A provider downloading and verifying a model before its route exists.",
             Self::Failure => "A provider load that failed during artifact verification.",
             Self::Offline => "Canonical routes exist, but no provider heartbeat is currently live.",
+            Self::SourceUpdate => "Newer GitHub source is available without a signed executable for this system.",
+            Self::SignedUpdate => "A newer GitHub release includes the complete signed executable asset set.",
             Self::UpdateRequired => "A catalog compatibility gate hides a model until the app is updated.",
             Self::Scale => "Ninety-six models, more than one hundred provider-scoped routes, ninety-six receipts, sixty-four access tokens, and sixty-four probes for testing reachability, renderer bounds, density, and mobile overflow.",
         }
@@ -135,6 +145,8 @@ impl WorkbenchState {
             WorkbenchScenario::Offline,
             base_state(workbench_models(4), false),
         );
+        scenarios.insert(WorkbenchScenario::SourceUpdate, github_update_state(false));
+        scenarios.insert(WorkbenchScenario::SignedUpdate, github_update_state(true));
         scenarios.insert(
             WorkbenchScenario::UpdateRequired,
             showcase_state(3).with_hidden_update_models(vec![GatewayUpdateModelNotice {
@@ -164,6 +176,48 @@ impl WorkbenchState {
             .cloned()
             .unwrap_or_else(GatewayState::fixture)
     }
+}
+
+fn github_update_state(installable: bool) -> GatewayState {
+    let update = if installable {
+        GatewayGithubUpdate {
+            kind: "release".to_owned(),
+            installed_version: installed_app_version().to_owned(),
+            available_version: Some("0.3.0".to_owned()),
+            installed_revision: Some("1".repeat(40)),
+            available_revision: None,
+            release_url: Some(
+                "https://github.com/Trac-Systems/openmayhem/releases/tag/0.3.0".to_owned(),
+            ),
+            compare_url: None,
+            published_at: Some("2026-07-18T12:00:00Z".to_owned()),
+            installable: true,
+            message: "Mayhem 0.3.0 is available as a signed update for this system.".to_owned(),
+        }
+    } else {
+        GatewayGithubUpdate {
+            kind: "source".to_owned(),
+            installed_version: installed_app_version().to_owned(),
+            available_version: None,
+            installed_revision: Some("1".repeat(40)),
+            available_revision: Some("2".repeat(40)),
+            release_url: None,
+            compare_url: Some(
+                "https://github.com/Trac-Systems/openmayhem/compare/source...main".to_owned(),
+            ),
+            published_at: None,
+            installable: false,
+            message: "3 newer source changes are available on GitHub.".to_owned(),
+        }
+    };
+    showcase_state(4).with_github_update_status(GatewayGithubUpdateStatus {
+        state: "available".to_owned(),
+        installed_version: installed_app_version().to_owned(),
+        installed_revision: Some("1".repeat(40)),
+        checked_at_seconds: Some(now_secs()),
+        message: update.message.clone(),
+        update: Some(update),
+    })
 }
 
 #[derive(Debug, Default, Deserialize)]
@@ -903,6 +957,8 @@ fn workbench_scenario_blocker(
             "The fixture catalog has routes, but none has a fresh provider heartbeat.",
         )),
         WorkbenchScenario::Showcase
+        | WorkbenchScenario::SourceUpdate
+        | WorkbenchScenario::SignedUpdate
         | WorkbenchScenario::UpdateRequired
         | WorkbenchScenario::Scale => None,
     }

--- a/crates/mayhem-gateway/src/openai/github_update.rs
+++ b/crates/mayhem-gateway/src/openai/github_update.rs
@@ -1,0 +1,496 @@
+use std::{env, time::Duration};
+
+use reqwest::{
+    header::{ETAG, IF_NONE_MATCH},
+    Client, StatusCode,
+};
+use semver::Version;
+use serde::{de::DeserializeOwned, Deserialize, Serialize};
+
+const DEFAULT_GITHUB_REPOSITORY_API_URL: &str =
+    "https://api.github.com/repos/Trac-Systems/openmayhem";
+const DEFAULT_SOURCE_REF: &str = "main";
+const DEFAULT_CHECK_INTERVAL_SECONDS: u64 = 12 * 60 * 60;
+const MIN_CHECK_INTERVAL_SECONDS: u64 = 5 * 60;
+const DEFAULT_REQUEST_TIMEOUT_SECONDS: u64 = 4;
+
+#[derive(Clone, Debug, Serialize, Deserialize, Eq, PartialEq)]
+pub struct GatewayGithubUpdate {
+    pub kind: String,
+    pub installed_version: String,
+    pub available_version: Option<String>,
+    pub installed_revision: Option<String>,
+    pub available_revision: Option<String>,
+    pub release_url: Option<String>,
+    pub compare_url: Option<String>,
+    pub published_at: Option<String>,
+    pub installable: bool,
+    pub message: String,
+}
+
+#[derive(Clone, Debug, Serialize, Deserialize, Eq, PartialEq)]
+pub struct GatewayGithubUpdateStatus {
+    pub state: String,
+    pub installed_version: String,
+    pub installed_revision: Option<String>,
+    pub checked_at_seconds: Option<u64>,
+    pub update: Option<GatewayGithubUpdate>,
+    pub message: String,
+}
+
+impl GatewayGithubUpdateStatus {
+    pub(super) fn disabled() -> Self {
+        Self {
+            state: "disabled".to_owned(),
+            installed_version: installed_app_version().to_owned(),
+            installed_revision: installed_source_revision(),
+            checked_at_seconds: None,
+            update: None,
+            message: "Automatic GitHub update checks are disabled.".to_owned(),
+        }
+    }
+
+    pub(super) fn checking() -> Self {
+        Self {
+            state: "checking".to_owned(),
+            installed_version: installed_app_version().to_owned(),
+            installed_revision: installed_source_revision(),
+            checked_at_seconds: None,
+            update: None,
+            message: "Checking GitHub for newer Mayhem source and signed releases.".to_owned(),
+        }
+    }
+
+    fn unavailable(checked_at_seconds: u64) -> Self {
+        Self {
+            state: "unavailable".to_owned(),
+            installed_version: installed_app_version().to_owned(),
+            installed_revision: installed_source_revision(),
+            checked_at_seconds: Some(checked_at_seconds),
+            update: None,
+            message: "GitHub could not be checked. Mayhem continues normally.".to_owned(),
+        }
+    }
+}
+
+#[derive(Clone, Debug)]
+pub(super) struct GithubUpdateCheckConfig {
+    repository_api_url: String,
+    release_feed_url: String,
+    source_ref: String,
+    target: String,
+    request_timeout: Duration,
+    pub interval: Duration,
+}
+
+impl GithubUpdateCheckConfig {
+    pub(super) fn from_env() -> Self {
+        let repository_api_url = env::var("MAYHEM_GITHUB_REPOSITORY_API_URL")
+            .ok()
+            .filter(|value| !value.trim().is_empty())
+            .unwrap_or_else(|| DEFAULT_GITHUB_REPOSITORY_API_URL.to_owned())
+            .trim_end_matches('/')
+            .to_owned();
+        let release_feed_url = env::var("MAYHEM_RELEASE_FEED_URL")
+            .ok()
+            .filter(|value| !value.trim().is_empty())
+            .unwrap_or_else(|| format!("{repository_api_url}/releases/latest"));
+        let source_ref = env::var("MAYHEM_GITHUB_SOURCE_REF")
+            .ok()
+            .filter(|value| valid_source_ref(value))
+            .unwrap_or_else(|| DEFAULT_SOURCE_REF.to_owned());
+        let interval_seconds = env_u64("MAYHEM_UPDATE_CHECK_INTERVAL_SECONDS")
+            .unwrap_or(DEFAULT_CHECK_INTERVAL_SECONDS)
+            .max(MIN_CHECK_INTERVAL_SECONDS);
+        let timeout_seconds = env_u64("MAYHEM_UPDATE_CHECK_TIMEOUT_SECONDS")
+            .unwrap_or(DEFAULT_REQUEST_TIMEOUT_SECONDS)
+            .clamp(1, 30);
+        Self {
+            repository_api_url,
+            release_feed_url,
+            source_ref,
+            target: release_host_target(),
+            request_timeout: Duration::from_secs(timeout_seconds),
+            interval: Duration::from_secs(interval_seconds),
+        }
+    }
+}
+
+#[derive(Clone, Debug, Deserialize)]
+struct GithubRelease {
+    tag_name: String,
+    html_url: String,
+    published_at: Option<String>,
+    #[serde(default)]
+    draft: bool,
+    #[serde(default)]
+    prerelease: bool,
+    #[serde(default)]
+    assets: Vec<GithubReleaseAsset>,
+}
+
+#[derive(Clone, Debug, Deserialize)]
+struct GithubReleaseAsset {
+    name: String,
+}
+
+#[derive(Clone, Debug, Deserialize)]
+struct GithubCompare {
+    status: String,
+    #[serde(default)]
+    ahead_by: u64,
+    html_url: String,
+    #[serde(default)]
+    commits: Vec<GithubCommit>,
+}
+
+#[derive(Clone, Debug, Deserialize)]
+struct GithubCommit {
+    sha: String,
+}
+
+#[derive(Debug, Default)]
+pub(super) struct GithubUpdateCache {
+    release: EndpointCache<GithubRelease>,
+    compare: EndpointCache<GithubCompare>,
+}
+
+#[derive(Debug)]
+struct EndpointCache<T> {
+    etag: Option<String>,
+    value: Option<T>,
+}
+
+impl<T> Default for EndpointCache<T> {
+    fn default() -> Self {
+        Self {
+            etag: None,
+            value: None,
+        }
+    }
+}
+
+pub(super) async fn check_github_update(
+    config: &GithubUpdateCheckConfig,
+    cache: &mut GithubUpdateCache,
+    checked_at_seconds: u64,
+) -> GatewayGithubUpdateStatus {
+    let client = match Client::builder()
+        .user_agent(format!("mayhem-update-check/{}", installed_app_version()))
+        .timeout(config.request_timeout)
+        .build()
+    {
+        Ok(client) => client,
+        Err(_) => return GatewayGithubUpdateStatus::unavailable(checked_at_seconds),
+    };
+
+    let release = fetch_cached_json(&client, &config.release_feed_url, &mut cache.release).await;
+    let compare = match installed_source_revision() {
+        Some(revision) => {
+            let url = format!(
+                "{}/compare/{}...{}",
+                config.repository_api_url, revision, config.source_ref
+            );
+            fetch_cached_json(&client, &url, &mut cache.compare).await
+        }
+        None => Ok(None),
+    };
+    if release.is_err() && compare.is_err() {
+        return GatewayGithubUpdateStatus::unavailable(checked_at_seconds);
+    }
+    evaluate_github_update(
+        installed_app_version(),
+        installed_source_revision().as_deref(),
+        release.ok().flatten().as_ref(),
+        compare.ok().flatten().as_ref(),
+        &config.target,
+        checked_at_seconds,
+    )
+}
+
+async fn fetch_cached_json<T>(
+    client: &Client,
+    url: &str,
+    cache: &mut EndpointCache<T>,
+) -> Result<Option<T>, String>
+where
+    T: Clone + DeserializeOwned,
+{
+    let mut request = client.get(url);
+    if let Some(etag) = cache.etag.as_deref() {
+        request = request.header(IF_NONE_MATCH, etag);
+    }
+    let response = request.send().await.map_err(|error| error.to_string())?;
+    if response.status() == StatusCode::NOT_MODIFIED {
+        return Ok(cache.value.clone());
+    }
+    if response.status() == StatusCode::NOT_FOUND {
+        cache.etag = None;
+        cache.value = None;
+        return Ok(None);
+    }
+    let response = response
+        .error_for_status()
+        .map_err(|error| error.to_string())?;
+    let etag = response
+        .headers()
+        .get(ETAG)
+        .and_then(|value| value.to_str().ok())
+        .map(str::to_owned);
+    let value = response
+        .json::<T>()
+        .await
+        .map_err(|error| error.to_string())?;
+    cache.etag = etag;
+    cache.value = Some(value.clone());
+    Ok(Some(value))
+}
+
+fn evaluate_github_update(
+    installed_version: &str,
+    installed_revision: Option<&str>,
+    release: Option<&GithubRelease>,
+    compare: Option<&GithubCompare>,
+    target: &str,
+    checked_at_seconds: u64,
+) -> GatewayGithubUpdateStatus {
+    let release_update = release.and_then(|release| {
+        let installed = parse_version(installed_version)?;
+        let available = parse_version(&release.tag_name)?;
+        if release.draft
+            || release.prerelease
+            || !available.pre.is_empty()
+            || available <= installed
+        {
+            return None;
+        }
+        let installable = release_has_installable_assets(release, target);
+        Some(GatewayGithubUpdate {
+            kind: if installable { "release" } else { "source-release" }.to_owned(),
+            installed_version: installed_version.to_owned(),
+            available_version: Some(release.tag_name.clone()),
+            installed_revision: installed_revision.map(str::to_owned),
+            available_revision: None,
+            release_url: Some(release.html_url.clone()),
+            compare_url: None,
+            published_at: release.published_at.clone(),
+            installable,
+            message: if installable {
+                format!(
+                    "Mayhem {} is available as a signed update for this system.",
+                    release.tag_name
+                )
+            } else {
+                format!(
+                    "Mayhem {} is published on GitHub, but no signed executable is available for this system yet.",
+                    release.tag_name
+                )
+            },
+        })
+    });
+    let source_update = compare.and_then(|compare| {
+        if compare.status != "ahead" || compare.ahead_by == 0 {
+            return None;
+        }
+        Some(GatewayGithubUpdate {
+            kind: "source".to_owned(),
+            installed_version: installed_version.to_owned(),
+            available_version: None,
+            installed_revision: installed_revision.map(str::to_owned),
+            available_revision: compare.commits.last().map(|commit| commit.sha.clone()),
+            release_url: None,
+            compare_url: Some(compare.html_url.clone()),
+            published_at: None,
+            installable: false,
+            message: format!(
+                "{} newer source {} available on GitHub.",
+                compare.ahead_by,
+                if compare.ahead_by == 1 {
+                    "change is"
+                } else {
+                    "changes are"
+                }
+            ),
+        })
+    });
+    let update = release_update.or(source_update);
+    GatewayGithubUpdateStatus {
+        state: if update.is_some() {
+            "available"
+        } else {
+            "current"
+        }
+        .to_owned(),
+        installed_version: installed_version.to_owned(),
+        installed_revision: installed_revision.map(str::to_owned),
+        checked_at_seconds: Some(checked_at_seconds),
+        message: update
+            .as_ref()
+            .map(|update| update.message.clone())
+            .unwrap_or_else(|| {
+                "This Mayhem build is current with the configured GitHub source.".to_owned()
+            }),
+        update,
+    }
+}
+
+fn release_has_installable_assets(release: &GithubRelease, target: &str) -> bool {
+    let base = format!("mayhem-{}-{target}", release.tag_name);
+    let archive_tar = format!("{base}.tar.gz");
+    let archive_zip = format!("{base}.zip");
+    let manifest = format!("{base}.manifest.json");
+    let signature = format!("{manifest}.sig");
+    let has = |name: &str| release.assets.iter().any(|asset| asset.name == name);
+    (has(&archive_tar) || has(&archive_zip)) && has(&manifest) && has(&signature)
+}
+
+pub(super) fn automatic_update_check_enabled() -> bool {
+    !env::var("MAYHEM_UPDATE_CHECK").ok().is_some_and(|value| {
+        matches!(
+            value.trim().to_ascii_lowercase().as_str(),
+            "0" | "false" | "no" | "off"
+        )
+    })
+}
+
+pub(super) fn installed_app_version() -> &'static str {
+    env!("CARGO_PKG_VERSION")
+}
+
+pub(super) fn installed_source_revision() -> Option<String> {
+    let revision = env!("MAYHEM_BUILD_GIT_SHA");
+    is_git_revision(revision).then(|| revision.to_ascii_lowercase())
+}
+
+fn parse_version(value: &str) -> Option<Version> {
+    Version::parse(value.trim().trim_start_matches('v')).ok()
+}
+
+fn release_host_target() -> String {
+    let arch = env::consts::ARCH;
+    let os = match env::consts::OS {
+        "macos" => "apple-darwin",
+        "linux" => "unknown-linux-gnu",
+        "windows" => "pc-windows-msvc",
+        other => other,
+    };
+    format!("{arch}-{os}")
+}
+
+fn valid_source_ref(value: &str) -> bool {
+    !value.is_empty()
+        && value.len() <= 128
+        && value
+            .bytes()
+            .all(|byte| byte.is_ascii_alphanumeric() || matches!(byte, b'-' | b'_' | b'.' | b'/'))
+}
+
+fn is_git_revision(value: &str) -> bool {
+    value.len() == 40 && value.bytes().all(|byte| byte.is_ascii_hexdigit())
+}
+
+fn env_u64(name: &str) -> Option<u64> {
+    env::var(name).ok()?.trim().parse().ok()
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn release(tag: &str, assets: &[&str]) -> GithubRelease {
+        GithubRelease {
+            tag_name: tag.to_owned(),
+            html_url: format!("https://github.test/releases/{tag}"),
+            published_at: Some("2026-07-18T12:00:00Z".to_owned()),
+            draft: false,
+            prerelease: false,
+            assets: assets
+                .iter()
+                .map(|name| GithubReleaseAsset {
+                    name: (*name).to_owned(),
+                })
+                .collect(),
+        }
+    }
+
+    fn compare(ahead_by: u64) -> GithubCompare {
+        GithubCompare {
+            status: if ahead_by == 0 { "identical" } else { "ahead" }.to_owned(),
+            ahead_by,
+            html_url: "https://github.test/compare/current...main".to_owned(),
+            commits: (0..ahead_by)
+                .map(|index| GithubCommit {
+                    sha: format!("{index:040x}"),
+                })
+                .collect(),
+        }
+    }
+
+    #[test]
+    fn source_changes_are_visible_without_claiming_an_installable_release() {
+        let status = evaluate_github_update(
+            "0.2.0",
+            Some("1111111111111111111111111111111111111111"),
+            None,
+            Some(&compare(3)),
+            "x86_64-pc-windows-msvc",
+            42,
+        );
+        let update = status.update.expect("source update");
+        assert_eq!(update.kind, "source");
+        assert!(!update.installable);
+        assert!(update.message.contains("3 newer source changes"));
+    }
+
+    #[test]
+    fn source_only_release_is_distinct_from_a_signed_executable() {
+        let status = evaluate_github_update(
+            "0.2.0",
+            None,
+            Some(&release("0.3.0", &[])),
+            None,
+            "x86_64-pc-windows-msvc",
+            42,
+        );
+        let update = status.update.expect("source release");
+        assert_eq!(update.kind, "source-release");
+        assert!(!update.installable);
+    }
+
+    #[test]
+    fn complete_signed_assets_enable_the_existing_updater_automatically() {
+        let target = "x86_64-pc-windows-msvc";
+        let base = format!("mayhem-0.3.0-{target}");
+        let assets = [
+            format!("{base}.zip"),
+            format!("{base}.manifest.json"),
+            format!("{base}.manifest.json.sig"),
+        ];
+        let asset_refs = assets.iter().map(String::as_str).collect::<Vec<_>>();
+        let status = evaluate_github_update(
+            "0.2.0",
+            None,
+            Some(&release("0.3.0", &asset_refs)),
+            None,
+            target,
+            42,
+        );
+        let update = status.update.expect("installable release");
+        assert_eq!(update.kind, "release");
+        assert!(update.installable);
+    }
+
+    #[test]
+    fn beta_tag_does_not_downgrade_a_stable_build() {
+        let status = evaluate_github_update(
+            "0.2.0",
+            None,
+            Some(&release("0.2.0-beta", &[])),
+            None,
+            "x86_64-pc-windows-msvc",
+            42,
+        );
+        assert_eq!(status.state, "current");
+        assert!(status.update.is_none());
+    }
+}

--- a/crates/mayhem-gateway/tests/dashboard-browser-smoke.mjs
+++ b/crates/mayhem-gateway/tests/dashboard-browser-smoke.mjs
@@ -216,7 +216,7 @@ try {
     await open(path);
     equal(await page.locator('h1').innerText(), heading, 'page naming', `uses the descriptive heading for ${path}`);
   }
-  for (const scenario of ['auth-required', 'empty', 'loading', 'failure', 'offline', 'update-required']) {
+  for (const scenario of ['auth-required', 'empty', 'loading', 'failure', 'offline', 'source-update', 'signed-update', 'update-required']) {
     await open('/mayhem/dashboard', scenario);
     equal(await page.locator('h1').innerText(), 'Overview', 'page naming', `keeps the Home heading stable in ${scenario}`);
     await open('/mayhem/dashboard/earn', scenario);
@@ -233,6 +233,43 @@ try {
     'uses a complete gear outline for Settings',
   );
 
+  await page.setViewportSize({ width: 1440, height: 900 });
+  await open('/mayhem/dashboard', 'source-update');
+  const sourceUpdateNotice = page.locator('[data-update-notice]');
+  check(await sourceUpdateNotice.isVisible(), 'update notice', 'shows a compact notice for newer GitHub source');
+  check((await sourceUpdateNotice.innerText()).includes('Source update available'), 'update notice', 'labels a source-only update without implying an executable exists');
+  check(await page.locator('.app-nav a[href="/mayhem/dashboard/settings"] .nav-update-badge').isVisible(), 'update notice', 'keeps a persistent update marker beside Settings');
+  await sourceUpdateNotice.getByRole('button', { name: /Dismiss/ }).click();
+  check(!await sourceUpdateNotice.isVisible(), 'update notice', 'allows the lightweight notice to be dismissed');
+  await open('/mayhem/dashboard', 'source-update');
+  check(!await page.locator('[data-update-notice]').isVisible(), 'update notice', 'remembers dismissal for the same source revision');
+  check(await page.locator('.app-nav a[href="/mayhem/dashboard/settings"] .nav-update-badge').isVisible(), 'update notice', 'preserves the Settings marker after dismissal');
+  await open('/mayhem/dashboard/settings', 'source-update');
+  check(await page.getByText('Source update only.', { exact: true }).isVisible(), 'source update', 'explains the source-only installation path');
+  check(await page.getByRole('link', { name: /View changes on GitHub/ }).isVisible(), 'source update', 'links to the source comparison');
+  equal(await page.locator('#mayhem-update-stage-command').count(), 0, 'source update', 'does not offer the binary updater without signed assets');
+
+  await open('/mayhem/dashboard', 'signed-update');
+  check((await page.locator('[data-update-notice]').innerText()).includes('0.3.0 available'), 'signed update', 'names the installable release in the compact notice');
+  await open('/mayhem/dashboard/settings', 'signed-update');
+  check(await page.getByText('Agent-guided update recommended.', { exact: true }).isVisible(), 'signed update', 'recommends guided updating while preserving user review');
+  check(await page.getByRole('link', { name: /View release notes/ }).isVisible(), 'signed update', 'links to release notes');
+  equal(await page.locator('#mayhem-update-stage-command').innerText(), 'mayhem update', 'signed update', 'offers verified staging when signed assets exist');
+  equal(await page.locator('#mayhem-update-apply-command').innerText(), 'mayhem update --apply-staged', 'signed update', 'keeps update application explicit and separate');
+
+  await page.setViewportSize({ width: 390, height: 844 });
+  await open('/mayhem/dashboard', 'signed-update');
+  const mobileUpdateBounds = await page.locator('[data-update-notice]').evaluate((element) => {
+    const rect = element.getBoundingClientRect();
+    return {
+      visible: rect.width > 0 && rect.height > 0,
+      insideViewport: rect.left >= 0 && rect.right <= window.innerWidth,
+    };
+  });
+  check(mobileUpdateBounds.visible, 'signed update', 'keeps the update notice visible on mobile');
+  check(mobileUpdateBounds.insideViewport, 'signed update', 'fits the compact update notice inside a mobile viewport');
+
+  await page.setViewportSize({ width: 1440, height: 900 });
   await open('/mayhem/dashboard/help');
   equal(await page.locator('h1').innerText(), 'Help', 'Help experience', 'uses a stable page title');
   equal(await page.locator('.page-head-actions').locator('a,button').count(), 0, 'Help experience', 'does not duplicate a task action in the page header');
@@ -253,6 +290,7 @@ try {
   check(await page.locator('#app-navigation').evaluate((drawer) => drawer.contains(document.activeElement)), 'mobile drawer', 'moves focus into the drawer');
   await page.keyboard.press('Escape');
   check(!await page.locator('body').evaluate((body) => body.classList.contains('nav-open')), 'mobile drawer', 'closes with Escape');
+  await page.waitForFunction(() => document.querySelector('.mobile-menu-button') === document.activeElement);
   check(await menu.evaluate((button) => button === document.activeElement), 'mobile drawer', 'returns focus to the trigger');
 
   await open('/mayhem/dashboard/playground');

--- a/crates/mayhem-gateway/tests/openai_api.rs
+++ b/crates/mayhem-gateway/tests/openai_api.rs
@@ -5472,6 +5472,8 @@ async fn mayhem_local_endpoints_report_status_receipts_and_balance() {
     assert_eq!(body["ok"], true);
     assert_eq!(body["backend"], "local-openai-shape");
     assert_eq!(body["dev_session_shim"], true);
+    assert_eq!(body["github_update"]["state"], "disabled");
+    assert!(body["github_update"]["update"].is_null());
 
     let (status, body) =
         json_request(test_app(), Method::GET, "/mayhem/receipts", Value::Null).await;

--- a/scripts/dashboard-workbench-smoke.mjs
+++ b/scripts/dashboard-workbench-smoke.mjs
@@ -34,6 +34,8 @@ const EXPECTED_SCENARIOS = [
   'loading',
   'failure',
   'offline',
+  'source-update',
+  'signed-update',
   'update-required',
   'scale',
 ];
@@ -45,6 +47,8 @@ const SCENARIO_TITLES = new Map([
   ['loading', 'Provider loading'],
   ['failure', 'Provider failure'],
   ['offline', 'Routes offline'],
+  ['source-update', 'Source update'],
+  ['signed-update', 'Signed update'],
   ['update-required', 'Update required'],
   ['scale', 'Scale and overflow'],
 ]);
@@ -264,6 +268,8 @@ const SCENARIO_ROUTE_IDS = {
     'earn-opportunities', 'earn-reliability', 'network', 'network-models',
     'network-providers', 'network-markets', 'network-activity', 'network-evidence',
   ]),
+  'source-update': new Set(PRODUCT_ROUTES.map((route) => route.id)),
+  'signed-update': new Set(PRODUCT_ROUTES.map((route) => route.id)),
   'update-required': new Set(PRODUCT_ROUTES.map((route) => route.id)),
   scale: new Set([
     'home', 'models', 'activity', 'connect', 'earn', 'earn-machines',
@@ -713,6 +719,14 @@ function containsOnlyLoopbackHttpUrls(html) {
   }
 }
 
+function containsOnlySafeHttpsLinks(html) {
+  const withoutSafeGithubLinks = html.replaceAll(
+    /href="https:\/\/github\.com\/[^"\s]+" target="_blank" rel="noopener noreferrer"/g,
+    '',
+  );
+  return !withoutSafeGithubLinks.includes('https://');
+}
+
 function checkHtmlResponse(report, response, scope) {
   report.equal(response.status, 200, scope, 'returns HTTP 200');
   report.check(
@@ -737,7 +751,11 @@ function checkHtmlResponse(report, response, scope) {
   report.includes(response.text, 'name="viewport"', scope, 'declares a responsive viewport');
   report.includes(response.text, '</html>', scope, 'closes the HTML document');
   report.check(!response.text.includes('\uFFFD'), scope, 'contains no UTF-8 replacement characters');
-  report.check(!response.text.includes('https://'), scope, 'loads no HTTPS/external resources');
+  report.check(
+    containsOnlySafeHttpsLinks(response.text),
+    scope,
+    'loads no external HTTPS resources and allows only hardened GitHub links',
+  );
   report.check(
     containsOnlyLoopbackHttpUrls(response.text),
     scope,
@@ -979,6 +997,27 @@ function checkScenarioSemantics(report, scenario, route, html) {
       report.includes(html, 'id="mayhem-update-stage-command"', scope, 'shows the verified staging step directly');
       report.includes(html, 'id="mayhem-update-apply-command"', scope, 'shows the separate apply step directly');
       report.includes(html, 'mayhem update --apply-staged', scope, 'does not present staging alone as a completed update');
+    }
+  }
+
+  if (scenario === 'source-update' || scenario === 'signed-update') {
+    report.includes(html, 'data-update-notice', scope, 'renders the compact topbar update notice');
+    report.includes(html, 'nav-update-badge info', scope, 'keeps a persistent update marker beside Settings');
+    report.check(
+      !html.includes('<section class="attention-card warn" role="status"><span class="attention-icon" aria-hidden="true">!</span><div class="attention-copy"><strong>Update available</strong>'),
+      scope,
+      'does not render a large optional update banner',
+    );
+    if (route.id === 'settings' && scenario === 'source-update') {
+      report.includes(html, 'Source update only.', scope, 'explains that source changes are not an executable update');
+      report.includes(html, 'View changes on GitHub', scope, 'links to the GitHub source comparison');
+      report.check(!html.includes('id="mayhem-update-stage-command"'), scope, 'does not offer an updater command without signed assets');
+    }
+    if (route.id === 'settings' && scenario === 'signed-update') {
+      report.includes(html, 'Agent-guided update recommended.', scope, 'recommends guided updating while preserving user review');
+      report.includes(html, 'View release notes', scope, 'links to the signed release notes');
+      report.includes(html, 'id="mayhem-update-stage-command"', scope, 'offers the updater only when the complete signed asset set exists');
+      report.includes(html, 'id="mayhem-update-apply-command"', scope, 'keeps staging and application separate');
     }
   }
 }


### PR DESCRIPTION
## Summary
- add a non-blocking, server-side GitHub update check with a 12-hour cache interval, ETag revalidation, and a short timeout
- distinguish newer source, source-only GitHub releases, and host-specific signed executable releases
- automatically switch to the existing verified staged updater only when the release contains the expected archive, manifest, and signature assets
- show a compact dismissible top-bar notice plus a persistent Settings marker, with clear source-build or signed-update guidance
- add source-update and signed-update workbench fixtures plus Rust, static, responsive, accessibility, and browser coverage

## Update behavior
- Current source-only phase: links to the GitHub comparison/release and never presents the binary updater as available.
- Future executable phase: when a newer stable release publishes the complete target asset set, Settings automatically offers `mayhem update` followed by the explicit staged apply command.
- Mayhem never self-updates from the dashboard. The UI recommends agent-guided steps while requiring the user to review and run each command.
- Checks run from the gateway process, not the browser. Set `MAYHEM_UPDATE_CHECK=off` to disable them.

## Verification
- `cargo fmt --all -- --check`
- `cargo test -p mayhem-gateway --features dashboard-workbench github_update -- --nocapture`
- `cargo test -p mayhem-gateway --features dashboard-workbench dashboard -- --nocapture`
- `cargo test -p mayhem-gateway mayhem_local_endpoints_report_status_receipts_and_balance -- --nocapture`
- `cargo check -p mayhem-cli`
- `node scripts/dashboard-workbench-smoke.mjs` (10,867 assertions)
- `node crates/mayhem-gateway/tests/dashboard-browser-smoke.mjs --base-url http://127.0.0.1:11438` (1,572 assertions, 20 routes, 6 viewport classes)
- `git diff --check`

## Existing repository checks
The repository-wide sellable-surface audit and Rust 1.93 `clippy -D warnings` still report findings already present on `main` in unrelated catalog, README, gateway, protocol, and test code. This PR does not broaden into those existing cleanup areas.