### PR TITLE
Keep dashboard authentication for the gateway lifetime

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -50,10 +50,23 @@ htmlcov/
 tmp/
 temp/
 coverage/
+.coverage.*
+coverage-final.json
+lcov.info
+*.profraw
+*.profdata
 .nyc_output/
 playwright-report/
 test-results/
+test-reports/
+test-artifacts/
 blob-report/
+allure-results/
+allure-report/
+junit.xml
+junit-*.xml
+cobertura.xml
+*.snap.new
 
 # Local runtime state
 stores/

--- a/README.md
+++ b/README.md
@@ -792,6 +792,12 @@ http://127.0.0.1:11435/mayhem/dashboard?token=<generated-token>
 http://127.0.0.1:11435/mayhem/dashboard/provider?token=<generated-token>
 ```
 
+Open the tokenized URL once for each gateway run. The gateway exchanges it for an
+HttpOnly browser cookie and redirects to a clean dashboard URL. That browser remains
+authenticated without an idle timeout, including after closing and reopening it, for
+as long as the same gateway process is running. Restarting the gateway rotates both
+secrets, so the newly printed URL must be opened once again.
+
 When Mayhem runs on a remote machine, forward the same loopback port and then open the URL printed
 by `mayhem up`:
 

--- a/crates/mayhem-cli/src/main.rs
+++ b/crates/mayhem-cli/src/main.rs
@@ -32817,7 +32817,6 @@ async fn use_gateway(args: UseArgs) -> Result<()> {
     );
     let dashboard_url = state.dashboard_url(&gateway_url);
     let provider_dashboard_url = provider_dashboard_url_from_user(&dashboard_url);
-    let dashboard_browser_idle_timeout_seconds = state.dashboard_session_expires_in().as_secs();
     let report = json!({
         "ok": true,
         "home": home,
@@ -32826,7 +32825,7 @@ async fn use_gateway(args: UseArgs) -> Result<()> {
         "openai_base_url": openai_base_url,
         "dashboard_url": dashboard_url,
         "provider_dashboard_url": provider_dashboard_url,
-        "dashboard_browser_idle_timeout_seconds": dashboard_browser_idle_timeout_seconds,
+        "dashboard_browser_session_scope": "gateway_process",
         "source": source,
         "backend": backend,
         "epoch_seconds": state.epoch_seconds(),
@@ -32877,9 +32876,7 @@ async fn use_gateway(args: UseArgs) -> Result<()> {
         if let Some(notice) = shared_gateway_notice {
             println!("{notice}");
         }
-        println!(
-            "Dashboard browser idle timeout: {dashboard_browser_idle_timeout_seconds}s (the copy/paste URL remains valid while this gateway runs)."
-        );
+        println!("Dashboard access: token required once per gateway run.");
         if args.dev_embedded_catalog {
             println!("Model source: development embedded catalog (non-canonical).");
             println!("Backend: local OpenAI-shape smoke backend (unbillable dev output).");

--- a/crates/mayhem-gateway/src/openai.rs
+++ b/crates/mayhem-gateway/src/openai.rs
@@ -58,8 +58,8 @@ use crate::{
 };
 use axum::{
     body::{Body, Bytes},
-    extract::{DefaultBodyLimit, Multipart, Path, Query, State},
-    http::{header, HeaderMap, HeaderValue, StatusCode},
+    extract::{DefaultBodyLimit, Multipart, OriginalUri, Path, Query, State},
+    http::{header, HeaderMap, HeaderValue, StatusCode, Uri},
     response::{
         sse::{Event, Sse},
         IntoResponse, Response,
@@ -225,8 +225,12 @@ const CONTEXT_NEEDLE_FILLER_WORDS_PER_LINE: usize = 32;
 const DEFAULT_THROUGHPUT_FLOOR_SAMPLE_MILLIS: u64 = 1_000;
 const DEFAULT_EPOCH_SECONDS: u64 = 3_600;
 const TPM_ACTIVATION_CACHE_TTL_MILLIS: u64 = 24 * 60 * 60 * 1_000;
-const DASHBOARD_SESSION_TTL_SECONDS: u64 = 15 * 60;
 const DASHBOARD_COOKIE_NAME: &str = "mayhem_dashboard";
+// Browsers require persistent cookies to carry a finite lifetime. Keep the
+// cookie for the longest broadly supported window and refresh it on every
+// authenticated dashboard response. The in-memory gateway token remains the
+// authority, so restarting the gateway invalidates the cookie immediately.
+const DASHBOARD_COOKIE_MAX_AGE_SECONDS: u64 = 400 * 24 * 60 * 60;
 const DASHBOARD_PROVIDER_PROGRESS_ONLY_TTL_MS: u64 = 5 * 60 * 1000;
 const DASHBOARD_CSP: &str = "default-src 'self'; connect-src 'self' http://127.0.0.1:*; img-src 'self' data:; font-src 'self'; style-src 'self' 'unsafe-inline'; script-src 'self'; frame-ancestors 'none'; base-uri 'self'; form-action 'none'";
 #[derive(Clone, Debug)]
@@ -590,14 +594,7 @@ fn push_bounded<T>(items: &mut VecDeque<T>, item: T, max_items: usize) {
 #[derive(Clone)]
 struct DashboardSession {
     bootstrap_token: String,
-    browser: Arc<Mutex<DashboardBrowserSession>>,
-    ttl: Duration,
-}
-
-#[derive(Debug)]
-struct DashboardBrowserSession {
-    token: String,
-    last_seen: Instant,
+    browser_token: String,
 }
 
 impl fmt::Debug for DashboardSession {
@@ -605,8 +602,6 @@ impl fmt::Debug for DashboardSession {
         f.debug_struct("DashboardSession")
             .field("bootstrap_token", &"<redacted>")
             .field("browser_token", &"<redacted>")
-            .field("ttl", &self.ttl)
-            .field("expires_in", &self.expires_in())
             .finish()
     }
 }
@@ -615,42 +610,22 @@ impl DashboardSession {
     fn new() -> Self {
         Self {
             bootstrap_token: new_dashboard_token(),
-            browser: Arc::new(Mutex::new(DashboardBrowserSession {
-                token: new_dashboard_token(),
-                last_seen: Instant::now(),
-            })),
-            ttl: Duration::from_secs(DASHBOARD_SESSION_TTL_SECONDS),
+            browser_token: new_dashboard_token(),
         }
-    }
-
-    fn expires_in(&self) -> Duration {
-        self.ttl.saturating_sub(
-            self.browser
-                .lock_recover("dashboard browser session")
-                .last_seen
-                .elapsed(),
-        )
     }
 
     fn authorize_bootstrap(&self, token: &str) -> Option<String> {
         if token != self.bootstrap_token {
             return None;
         }
-        let mut browser = self.browser.lock_recover("dashboard browser session");
-        if browser.last_seen.elapsed() >= self.ttl {
-            browser.token = new_dashboard_token();
-        }
-        browser.last_seen = Instant::now();
-        Some(browser.token.clone())
+        Some(self.browser_token.clone())
     }
 
     fn authorize_browser(&self, token: &str) -> Option<String> {
-        let mut browser = self.browser.lock_recover("dashboard browser session");
-        if browser.last_seen.elapsed() >= self.ttl || token != browser.token {
+        if token != self.browser_token {
             return None;
         }
-        browser.last_seen = Instant::now();
-        Some(browser.token.clone())
+        Some(self.browser_token.clone())
     }
 }
 
@@ -3849,10 +3824,6 @@ impl GatewayState {
             gateway_root.trim_end_matches('/'),
             self.dashboard_session.bootstrap_token
         )
-    }
-
-    pub fn dashboard_session_expires_in(&self) -> Duration {
-        self.dashboard_session.expires_in()
     }
 
     pub fn with_hardware_quote_verifier_command(
@@ -8537,10 +8508,17 @@ struct DashboardQuery {
 
 async fn mayhem_dashboard(
     State(state): State<SharedState>,
+    OriginalUri(original_uri): OriginalUri,
     Query(query): Query<DashboardQuery>,
     headers: HeaderMap,
 ) -> Response {
-    dashboard_product_response(&state, &query, &headers, DashboardProductPage::Home)
+    dashboard_product_response(
+        &state,
+        &original_uri,
+        &query,
+        &headers,
+        DashboardProductPage::Home,
+    )
 }
 
 async fn mayhem_dashboard_root_redirect(
@@ -8548,14 +8526,16 @@ async fn mayhem_dashboard_root_redirect(
     Query(query): Query<DashboardQuery>,
     headers: HeaderMap,
 ) -> Response {
-    let browser_token = dashboard_request_authorized(&state, &headers, query.token.as_deref());
+    let authorization = dashboard_request_authorized(&state, &headers, query.token.as_deref());
     let mut response = StatusCode::PERMANENT_REDIRECT.into_response();
     response.headers_mut().insert(
         header::LOCATION,
         HeaderValue::from_static("/mayhem/dashboard"),
     );
-    if let Some(browser_token) = browser_token {
-        if let Ok(value) = HeaderValue::from_str(&dashboard_cookie_value(&browser_token)) {
+    if let Some(authorization) = authorization {
+        if let Ok(value) =
+            HeaderValue::from_str(&dashboard_cookie_value(&authorization.browser_token))
+        {
             response.headers_mut().append(header::SET_COOKIE, value);
         }
     }
@@ -8564,11 +8544,12 @@ async fn mayhem_dashboard_root_redirect(
 
 async fn mayhem_dashboard_evidence(
     State(state): State<SharedState>,
+    OriginalUri(original_uri): OriginalUri,
     Query(query): Query<DashboardQuery>,
     headers: HeaderMap,
 ) -> Response {
     let wants_json = dashboard_wants_json(&headers);
-    let Some(browser_token) =
+    let Some(authorization) =
         dashboard_request_authorized(&state, &headers, query.token.as_deref())
     else {
         return if wants_json {
@@ -8578,13 +8559,13 @@ async fn mayhem_dashboard_evidence(
                 None,
             )
         } else {
-            dashboard_html_response(
-                StatusCode::UNAUTHORIZED,
-                dashboard_locked_html(state.dashboard_session.expires_in().as_secs()),
-                None,
-            )
+            dashboard_html_response(StatusCode::UNAUTHORIZED, dashboard_locked_html(), None)
         };
     };
+    if let Some(response) = dashboard_bootstrap_redirect(&original_uri, &authorization) {
+        return response;
+    }
+    let browser_token = authorization.browser_token;
     let Some(payload) = dashboard_evidence_payload(&state, &query) else {
         return if wants_json {
             dashboard_json_response(
@@ -8627,82 +8608,95 @@ fn dashboard_wants_json(headers: &HeaderMap) -> bool {
 
 async fn mayhem_dashboard_provider(
     State(state): State<SharedState>,
+    OriginalUri(original_uri): OriginalUri,
     Query(query): Query<DashboardQuery>,
     headers: HeaderMap,
 ) -> Response {
-    dashboard_product_response(&state, &query, &headers, DashboardProductPage::Earn)
+    dashboard_product_response(
+        &state,
+        &original_uri,
+        &query,
+        &headers,
+        DashboardProductPage::Earn,
+    )
 }
 
 async fn mayhem_dashboard_network(
     State(state): State<SharedState>,
+    OriginalUri(original_uri): OriginalUri,
     Query(query): Query<DashboardQuery>,
     headers: HeaderMap,
 ) -> Response {
-    dashboard_product_response(&state, &query, &headers, DashboardProductPage::Network)
+    dashboard_product_response(
+        &state,
+        &original_uri,
+        &query,
+        &headers,
+        DashboardProductPage::Network,
+    )
 }
 
 async fn mayhem_dashboard_subpage(
     State(state): State<SharedState>,
+    OriginalUri(original_uri): OriginalUri,
     Path(page): Path<String>,
     Query(query): Query<DashboardQuery>,
     headers: HeaderMap,
 ) -> Response {
     let Some(page) = DashboardProductPage::from_path(&page) else {
-        let Some(browser_token) =
+        let Some(authorization) =
             dashboard_request_authorized(&state, &headers, query.token.as_deref())
         else {
             return dashboard_html_response(
                 StatusCode::UNAUTHORIZED,
-                dashboard_locked_html(state.dashboard_session.expires_in().as_secs()),
+                dashboard_locked_html(),
                 None,
             );
         };
+        if let Some(response) = dashboard_bootstrap_redirect(&original_uri, &authorization) {
+            return response;
+        }
         return dashboard_html_response(
             StatusCode::NOT_FOUND,
             dashboard_html_document(
                 "Not found",
                 r#"<main class="evidence-standalone"><section class="panel"><div class="empty-block"><div class="empty-block-inner"><div class="empty-symbol" aria-hidden="true">&mdash;</div><h1>Dashboard page not found</h1><p>The requested dashboard route does not exist.</p><a class="primary-button" href="/mayhem/dashboard">Return home</a></div></div></section></main>"#,
             ),
-            Some(&browser_token),
+            Some(&authorization.browser_token),
         );
     };
-    dashboard_product_response(&state, &query, &headers, page)
+    dashboard_product_response(&state, &original_uri, &query, &headers, page)
 }
 
 fn dashboard_product_response(
     state: &GatewayState,
+    original_uri: &Uri,
     query: &DashboardQuery,
     headers: &HeaderMap,
     page: DashboardProductPage,
 ) -> Response {
-    let Some(browser_token) = dashboard_request_authorized(state, headers, query.token.as_deref())
+    let Some(authorization) = dashboard_request_authorized(state, headers, query.token.as_deref())
     else {
-        return dashboard_html_response(
-            StatusCode::UNAUTHORIZED,
-            dashboard_locked_html(state.dashboard_session.expires_in().as_secs()),
-            None,
-        );
+        return dashboard_html_response(StatusCode::UNAUTHORIZED, dashboard_locked_html(), None);
     };
+    if let Some(response) = dashboard_bootstrap_redirect(original_uri, &authorization) {
+        return response;
+    }
     let origin = dashboard_origin_from_headers(headers);
     dashboard_html_response(
         StatusCode::OK,
-        render_dashboard_product_page(
-            state,
-            state.dashboard_session.expires_in().as_secs(),
-            &origin,
-            query,
-            page,
-        ),
-        Some(&browser_token),
+        render_dashboard_product_page(state, &origin, query, page),
+        Some(&authorization.browser_token),
     )
 }
 
 async fn mayhem_dashboard_session(
     State(state): State<SharedState>,
+    OriginalUri(original_uri): OriginalUri,
     Query(query): Query<DashboardQuery>,
     headers: HeaderMap,
 ) -> Response {
-    let Some(browser_token) =
+    let Some(authorization) =
         dashboard_request_authorized(&state, &headers, query.token.as_deref())
     else {
         return dashboard_json_response(
@@ -8714,11 +8708,14 @@ async fn mayhem_dashboard_session(
             None,
         );
     };
+    if let Some(response) = dashboard_bootstrap_redirect(&original_uri, &authorization) {
+        return response;
+    }
     dashboard_json_response(
         StatusCode::OK,
         json!({
             "ok": true,
-            "expires_in_seconds": state.dashboard_session.expires_in().as_secs(),
+            "session_scope": "gateway_process",
             "paths": {
                 "dashboard": "/mayhem/dashboard",
                 "network_dashboard": "/mayhem/dashboard/network",
@@ -8729,7 +8726,7 @@ async fn mayhem_dashboard_session(
                 "balance": "/mayhem/balance",
             },
         }),
-        Some(&browser_token),
+        Some(&authorization.browser_token),
     )
 }
 
@@ -8853,20 +8850,76 @@ async fn mayhem_balance(State(state): State<SharedState>, headers: HeaderMap) ->
     .into_response()
 }
 
+#[derive(Debug)]
+struct DashboardAuthorization {
+    browser_token: String,
+    bootstrapped_from_query: bool,
+}
+
 fn dashboard_request_authorized(
     state: &GatewayState,
     headers: &HeaderMap,
     query_token: Option<&str>,
-) -> Option<String> {
-    let bootstrap = query_token
+) -> Option<DashboardAuthorization> {
+    if let Some(browser_token) =
+        query_token.and_then(|token| state.dashboard_session.authorize_bootstrap(token))
+    {
+        return Some(DashboardAuthorization {
+            browser_token,
+            bootstrapped_from_query: true,
+        });
+    }
+    let browser_token = dashboard_header_token(headers)
         .into_iter()
-        .chain(dashboard_header_token(headers))
         .chain(dashboard_bearer_token(headers))
-        .find_map(|token| state.dashboard_session.authorize_bootstrap(token));
-    bootstrap.or_else(|| {
-        dashboard_cookie_token(headers)
-            .and_then(|token| state.dashboard_session.authorize_browser(token))
+        .find_map(|token| state.dashboard_session.authorize_bootstrap(token))
+        .or_else(|| {
+            dashboard_cookie_token(headers)
+                .and_then(|token| state.dashboard_session.authorize_browser(token))
+        })?;
+    Some(DashboardAuthorization {
+        browser_token,
+        bootstrapped_from_query: false,
     })
+}
+
+fn dashboard_bootstrap_redirect(
+    original_uri: &Uri,
+    authorization: &DashboardAuthorization,
+) -> Option<Response> {
+    if !authorization.bootstrapped_from_query {
+        return None;
+    }
+    let location = dashboard_uri_without_token(original_uri);
+    let mut response = StatusCode::SEE_OTHER.into_response();
+    response.headers_mut().insert(
+        header::LOCATION,
+        HeaderValue::from_str(&location)
+            .unwrap_or_else(|_| HeaderValue::from_static("/mayhem/dashboard")),
+    );
+    if let Ok(value) = HeaderValue::from_str(&dashboard_cookie_value(&authorization.browser_token))
+    {
+        response.headers_mut().append(header::SET_COOKIE, value);
+    }
+    Some(with_dashboard_security_headers(response))
+}
+
+fn dashboard_uri_without_token(uri: &Uri) -> String {
+    let path = if uri.path().is_empty() {
+        "/mayhem/dashboard"
+    } else {
+        uri.path()
+    };
+    let query = uri.query().map(|query| {
+        query
+            .split('&')
+            .filter(|part| part.split_once('=').map_or(*part, |(key, _)| key) != "token")
+            .collect::<Vec<_>>()
+            .join("&")
+    });
+    query
+        .filter(|query| !query.is_empty())
+        .map_or_else(|| path.to_owned(), |query| format!("{path}?{query}"))
 }
 
 fn dashboard_header_token(headers: &HeaderMap) -> Option<&str> {
@@ -8929,7 +8982,7 @@ fn dashboard_json_response(status: StatusCode, body: Value, token: Option<&str>)
 
 fn dashboard_cookie_value(token: &str) -> String {
     format!(
-        "{DASHBOARD_COOKIE_NAME}={token}; Path=/mayhem/dashboard; Max-Age={DASHBOARD_SESSION_TTL_SECONDS}; HttpOnly; SameSite=Strict"
+        "{DASHBOARD_COOKIE_NAME}={token}; Path=/mayhem/dashboard; Max-Age={DASHBOARD_COOKIE_MAX_AGE_SECONDS}; HttpOnly; SameSite=Strict"
     )
 }
 
@@ -8985,12 +9038,10 @@ fn dashboard_host_is_loopback(host: &str) -> bool {
     false
 }
 
-fn dashboard_locked_html(expires_in_seconds: u64) -> String {
+fn dashboard_locked_html() -> String {
     dashboard_html_document(
         "Locked",
-        &format!(
-            r#"<main class="evidence-standalone"><section class="panel"><div class="empty-block"><div class="empty-block-inner"><div class="empty-symbol" aria-hidden="true">M</div><h1>Dashboard locked</h1><p>Reopen the copy-and-paste dashboard URL printed by <code>mayhem up</code> to start a fresh browser session.</p><span class="status-badge warn mono">Browser idle window {expires_in_seconds}s</span></div></div></section></main>"#
-        ),
+        r#"<main class="evidence-standalone"><section class="panel"><div class="empty-block"><div class="empty-block-inner"><div class="empty-symbol" aria-hidden="true">M</div><h1>Dashboard access required</h1><p>Open the copy-and-paste dashboard URL printed when Mayhem started.</p><span class="status-badge warn mono">Token required for this gateway run</span></div></div></section></main>"#,
     )
 }
 
@@ -32680,7 +32731,6 @@ mod tests {
         ]);
         let user_html = render_dashboard_product_page(
             &state,
-            60,
             "http://127.0.0.1:11435",
             &DashboardQuery::default(),
             DashboardProductPage::Home,
@@ -32691,7 +32741,6 @@ mod tests {
 
         let provider_html = render_dashboard_product_page(
             &state,
-            60,
             "http://127.0.0.1:11435",
             &DashboardQuery::default(),
             DashboardProductPage::Earn,
@@ -36824,43 +36873,44 @@ mod tests {
     }
 
     #[test]
-    fn dashboard_session_slides_and_bootstrap_recovers_after_idle_expiry() {
+    fn dashboard_session_lasts_for_one_gateway_process() {
         let session = DashboardSession::new();
         let bootstrap_token = session.bootstrap_token.clone();
-        let first_browser_token = session
+        let browser_token = session
             .authorize_bootstrap(&bootstrap_token)
             .expect("bootstrap token opens a browser session");
-        assert_ne!(first_browser_token, bootstrap_token);
-
-        {
-            let mut browser = session.browser.lock_recover("dashboard browser session");
-            browser.last_seen = Instant::now()
-                .checked_sub(Duration::from_secs(30))
-                .expect("test clock can move backwards");
-        }
-        let before_refresh = session.expires_in();
+        assert_ne!(browser_token, bootstrap_token);
         assert_eq!(
-            session.authorize_browser(&first_browser_token),
-            Some(first_browser_token.clone())
+            session.authorize_browser(&browser_token),
+            Some(browser_token.clone())
         );
-        assert!(session.expires_in() > before_refresh);
-
-        {
-            let mut browser = session.browser.lock_recover("dashboard browser session");
-            browser.last_seen = Instant::now()
-                .checked_sub(session.ttl + Duration::from_secs(1))
-                .expect("test clock can move beyond the idle timeout");
-        }
-        assert_eq!(session.authorize_browser(&first_browser_token), None);
-
-        let reopened_browser_token = session
-            .authorize_bootstrap(&bootstrap_token)
-            .expect("bootstrap token reopens an expired browser session");
-        assert_ne!(reopened_browser_token, first_browser_token);
-        assert_eq!(session.authorize_browser(&first_browser_token), None);
         assert_eq!(
-            session.authorize_browser(&reopened_browser_token),
-            Some(reopened_browser_token)
+            session.authorize_bootstrap(&bootstrap_token),
+            Some(browser_token.clone())
+        );
+
+        let restarted = DashboardSession::new();
+        assert_eq!(restarted.authorize_bootstrap(&bootstrap_token), None);
+        assert_eq!(restarted.authorize_browser(&browser_token), None);
+        let restarted_browser_token = restarted
+            .authorize_bootstrap(&restarted.bootstrap_token)
+            .expect("new gateway process opens a new browser session");
+        assert_ne!(restarted_browser_token, browser_token);
+        assert_eq!(
+            restarted
+                .authorize_bootstrap(&restarted.bootstrap_token)
+                .as_deref(),
+            Some(restarted_browser_token.as_str())
+        );
+        assert_eq!(
+            restarted
+                .authorize_browser(&restarted_browser_token)
+                .as_deref(),
+            Some(restarted_browser_token.as_str())
+        );
+        assert_eq!(
+            session.authorize_bootstrap(&bootstrap_token).as_deref(),
+            Some(browser_token.as_str())
         );
     }
 
@@ -36874,7 +36924,8 @@ mod tests {
         assert!(DASHBOARD_APP_CSS.contains(".app-shell{min-height:100vh"));
         assert!(DASHBOARD_APP_CSS.contains("@media(max-width:780px)"));
         assert!(DASHBOARD_APP_CSS.contains(".data-table-wrap{width:100%;overflow:auto"));
-        assert!(DASHBOARD_APP_JS.contains("recordDashboardSessionActivity"));
+        assert!(!DASHBOARD_APP_JS.contains("recordDashboardSessionActivity"));
+        assert!(!DASHBOARD_APP_JS.contains("data-session-seconds"));
         assert!(!DASHBOARD_APP_JS.contains("document.addEventListener('visibilitychange'"));
     }
 

--- a/crates/mayhem-gateway/src/openai/dashboard_pages.rs
+++ b/crates/mayhem-gateway/src/openai/dashboard_pages.rs
@@ -636,81 +636,48 @@ fn route_operational_state(data: &DashboardData, entry: &ProviderTableEntry) -> 
 
 pub(super) fn render_dashboard_product_page(
     state: &GatewayState,
-    expires_in_seconds: u64,
     origin: &str,
     query: &DashboardQuery,
     page: DashboardProductPage,
 ) -> String {
     let data = DashboardData::from_state(state);
     let inner = match page {
-        DashboardProductPage::Home => home_page(&data, expires_in_seconds),
-        DashboardProductPage::Playground => {
-            playground_page(&data, expires_in_seconds, query.model.as_deref())
+        DashboardProductPage::Home => home_page(&data),
+        DashboardProductPage::Playground => playground_page(&data, query.model.as_deref()),
+        DashboardProductPage::Models => models_page(&data, query.page.as_deref()),
+        DashboardProductPage::Activity => activity_page(&data, query.page.as_deref()),
+        DashboardProductPage::Wallet => wallet_page(&data),
+        DashboardProductPage::Connect => connect_page(&data, origin, query.page.as_deref()),
+        DashboardProductPage::Earn => {
+            earn_overview_page(&data, query.provider.as_deref(), query.page.as_deref())
         }
-        DashboardProductPage::Models => {
-            models_page(&data, expires_in_seconds, query.page.as_deref())
+        DashboardProductPage::EarnJobs => {
+            earn_jobs_page(&data, query.provider.as_deref(), query.page.as_deref())
         }
-        DashboardProductPage::Activity => {
-            activity_page(&data, expires_in_seconds, query.page.as_deref())
+        DashboardProductPage::EarnMachines => {
+            earn_machines_page(&data, query.provider.as_deref(), query.page.as_deref())
         }
-        DashboardProductPage::Wallet => wallet_page(&data, expires_in_seconds),
-        DashboardProductPage::Connect => {
-            connect_page(&data, expires_in_seconds, origin, query.page.as_deref())
+        DashboardProductPage::EarnOpportunities => {
+            earn_opportunities_page(&data, query.provider.as_deref(), query.page.as_deref())
         }
-        DashboardProductPage::Earn => earn_overview_page(
-            &data,
-            expires_in_seconds,
-            query.provider.as_deref(),
-            query.page.as_deref(),
-        ),
-        DashboardProductPage::EarnJobs => earn_jobs_page(
-            &data,
-            expires_in_seconds,
-            query.provider.as_deref(),
-            query.page.as_deref(),
-        ),
-        DashboardProductPage::EarnMachines => earn_machines_page(
-            &data,
-            expires_in_seconds,
-            query.provider.as_deref(),
-            query.page.as_deref(),
-        ),
-        DashboardProductPage::EarnOpportunities => earn_opportunities_page(
-            &data,
-            expires_in_seconds,
-            query.provider.as_deref(),
-            query.page.as_deref(),
-        ),
-        DashboardProductPage::EarnEarnings => {
-            earn_earnings_page(&data, expires_in_seconds, query.provider.as_deref())
+        DashboardProductPage::EarnEarnings => earn_earnings_page(&data, query.provider.as_deref()),
+        DashboardProductPage::EarnReliability => {
+            earn_reliability_page(&data, query.provider.as_deref(), query.page.as_deref())
         }
-        DashboardProductPage::EarnReliability => earn_reliability_page(
-            &data,
-            expires_in_seconds,
-            query.provider.as_deref(),
-            query.page.as_deref(),
-        ),
-        DashboardProductPage::Network => network_overview_page(&data, expires_in_seconds),
-        DashboardProductPage::NetworkModels => {
-            network_models_page(&data, expires_in_seconds, query.page.as_deref())
-        }
+        DashboardProductPage::Network => network_overview_page(&data),
+        DashboardProductPage::NetworkModels => network_models_page(&data, query.page.as_deref()),
         DashboardProductPage::NetworkProviders => {
-            network_providers_page(&data, expires_in_seconds, query.page.as_deref())
+            network_providers_page(&data, query.page.as_deref())
         }
-        DashboardProductPage::NetworkMarkets => {
-            network_markets_page(&data, expires_in_seconds, query.page.as_deref())
-        }
+        DashboardProductPage::NetworkMarkets => network_markets_page(&data, query.page.as_deref()),
         DashboardProductPage::NetworkActivity => {
-            network_activity_page(&data, expires_in_seconds, query.page.as_deref())
+            network_activity_page(&data, query.page.as_deref())
         }
-        DashboardProductPage::NetworkEvidence => network_evidence_page(
-            &data,
-            expires_in_seconds,
-            query.page.as_deref(),
-            query.probe_page.as_deref(),
-        ),
-        DashboardProductPage::Help => help_page(&data, expires_in_seconds),
-        DashboardProductPage::Settings => settings_page(&data, expires_in_seconds),
+        DashboardProductPage::NetworkEvidence => {
+            network_evidence_page(&data, query.page.as_deref(), query.probe_page.as_deref())
+        }
+        DashboardProductPage::Help => help_page(&data),
+        DashboardProductPage::Settings => settings_page(&data),
     };
     dashboard_html_document(page.title(), &inner)
 }
@@ -1327,7 +1294,6 @@ fn volatile_page_status_marker(
 #[allow(clippy::too_many_arguments)]
 fn shell(
     data: &DashboardData,
-    expires: u64,
     page: DashboardAppPage,
     eyebrow: &str,
     heading: &str,
@@ -1338,7 +1304,7 @@ fn shell(
     content: &str,
 ) -> String {
     shell_impl(
-        data, expires, page, eyebrow, heading, summary, status, tone, actions, content, false,
+        data, page, eyebrow, heading, summary, status, tone, actions, content, false,
     )
 }
 
@@ -1347,7 +1313,6 @@ fn shell(
 #[allow(clippy::too_many_arguments)]
 fn shell_wide(
     data: &DashboardData,
-    expires: u64,
     page: DashboardAppPage,
     eyebrow: &str,
     heading: &str,
@@ -1358,14 +1323,13 @@ fn shell_wide(
     content: &str,
 ) -> String {
     shell_impl(
-        data, expires, page, eyebrow, heading, summary, status, tone, actions, content, true,
+        data, page, eyebrow, heading, summary, status, tone, actions, content, true,
     )
 }
 
 #[allow(clippy::too_many_arguments)]
 fn shell_impl(
     data: &DashboardData,
-    expires: u64,
     page: DashboardAppPage,
     eyebrow: &str,
     heading: &str,
@@ -1421,7 +1385,6 @@ fn shell_impl(
         settings_update_badge: &settings_update_badge,
         content: &content,
         footer: "Controls and evidence belong to this gateway process.",
-        expires_in_seconds: expires,
         wide,
     })
 }
@@ -1563,7 +1526,7 @@ fn global_update_attention(data: &DashboardData) -> String {
     )
 }
 
-fn home_page(data: &DashboardData, expires: u64) -> String {
+fn home_page(data: &DashboardData) -> String {
     let accepting_models = data.accepting_models();
     let completed = data.completed_requests();
     let incomplete = data.incomplete_session_count();
@@ -1663,7 +1626,6 @@ fn home_page(data: &DashboardData, expires: u64) -> String {
     };
     shell(
         data,
-        expires,
         DashboardAppPage::Home,
         "Overview",
         "Overview",
@@ -2639,7 +2601,7 @@ fn playground_text_parameter_schema(model: &GatewayModel) -> Value {
     })
 }
 
-fn playground_page(data: &DashboardData, expires: u64, selected_model: Option<&str>) -> String {
+fn playground_page(data: &DashboardData, selected_model: Option<&str>) -> String {
     let credential_needed = data.requires_auth() && data.active_token_count() == 0;
     let mut choices = data
         .models
@@ -2911,7 +2873,6 @@ fn playground_page(data: &DashboardData, expires: u64, selected_model: Option<&s
 
     shell(
         data,
-        expires,
         DashboardAppPage::Playground,
         "Use AI",
         "Playground",
@@ -2939,7 +2900,7 @@ fn playground_page(data: &DashboardData, expires: u64, selected_model: Option<&s
     )
 }
 
-fn models_page(data: &DashboardData, expires: u64, requested_page: Option<&str>) -> String {
+fn models_page(data: &DashboardData, requested_page: Option<&str>) -> String {
     let page = PageWindow::from_query(data.models.len(), MAX_MODEL_ROWS, requested_page);
     let rows = model_rows(data, page);
     let model_summary = page.status("catalog models");
@@ -2956,7 +2917,6 @@ fn models_page(data: &DashboardData, expires: u64, requested_page: Option<&str>)
     );
     shell_wide(
         data,
-        expires,
         DashboardAppPage::Models,
         "Use AI",
         "Model catalog",
@@ -3244,7 +3204,7 @@ fn model_catalog_price_html_with_limit(model: &GatewayModel, limit: Option<usize
     html
 }
 
-fn activity_page(data: &DashboardData, expires: u64, requested_page: Option<&str>) -> String {
+fn activity_page(data: &DashboardData, requested_page: Option<&str>) -> String {
     let records = prioritized_activity_records(data);
     let activity_count = records.len();
     let incomplete_count = data.incomplete_session_count();
@@ -3323,7 +3283,6 @@ fn activity_page(data: &DashboardData, expires: u64, requested_page: Option<&str
     };
     shell_wide(
         data,
-        expires,
         DashboardAppPage::Activity,
         "Use AI",
         "Requests and receipts",
@@ -3601,7 +3560,7 @@ fn wallet_deposit_status_command(rail: &str) -> String {
     }
 }
 
-fn wallet_page(data: &DashboardData, expires: u64) -> String {
+fn wallet_page(data: &DashboardData) -> String {
     let rail = data.rail.to_ascii_uppercase();
     let deposit_status_command = wallet_deposit_status_command(&data.rail);
     let observed = payment_freshness_markup(data);
@@ -3686,7 +3645,6 @@ fn wallet_page(data: &DashboardData, expires: u64) -> String {
     );
     shell(
         data,
-        expires,
         DashboardAppPage::Wallet,
         "Billing",
         "Billing",
@@ -3698,12 +3656,7 @@ fn wallet_page(data: &DashboardData, expires: u64) -> String {
     )
 }
 
-fn connect_page(
-    data: &DashboardData,
-    expires: u64,
-    origin: &str,
-    requested_page: Option<&str>,
-) -> String {
+fn connect_page(data: &DashboardData, origin: &str, requested_page: Option<&str>) -> String {
     let root = origin.trim_end_matches('/');
     let base_url = format!("{root}/v1");
     let token_count = data.active_token_count();
@@ -3824,7 +3777,6 @@ fn connect_page(
     );
     shell(
         data,
-        expires,
         DashboardAppPage::Connect,
         "Integrations",
         "Connect another AI app",
@@ -3945,7 +3897,6 @@ fn connect_token_rows(access: &Value, page: PageWindow) -> String {
 
 fn earn_overview_page(
     data: &DashboardData,
-    expires: u64,
     requested: Option<&str>,
     requested_page: Option<&str>,
 ) -> String {
@@ -4082,7 +4033,6 @@ fn earn_overview_page(
     );
     shell(
         data,
-        expires,
         DashboardAppPage::Earn,
         "Provider operations",
         "Provider overview",
@@ -4270,7 +4220,6 @@ fn provider_activation_panel(
 
 fn earn_jobs_page(
     data: &DashboardData,
-    expires: u64,
     requested: Option<&str>,
     requested_page: Option<&str>,
 ) -> String {
@@ -4394,7 +4343,6 @@ fn earn_jobs_page(
     );
     shell_wide(
         data,
-        expires,
         DashboardAppPage::Earn,
         "Provider work",
         "Jobs",
@@ -4426,7 +4374,6 @@ fn earn_jobs_page(
 
 fn earn_machines_page(
     data: &DashboardData,
-    expires: u64,
     requested: Option<&str>,
     requested_page: Option<&str>,
 ) -> String {
@@ -4457,7 +4404,6 @@ fn earn_machines_page(
     );
     shell_wide(
         data,
-        expires,
         DashboardAppPage::Earn,
         "Provider operations",
         "Machines and serving routes",
@@ -4471,7 +4417,6 @@ fn earn_machines_page(
 
 fn earn_opportunities_page(
     data: &DashboardData,
-    expires: u64,
     requested: Option<&str>,
     requested_page: Option<&str>,
 ) -> String {
@@ -4528,7 +4473,6 @@ fn earn_opportunities_page(
     let state = provider_page_state(data, requested, &provider_entries);
     shell_wide(
         data,
-        expires,
         DashboardAppPage::Earn,
         "Provider planning",
         "Model opportunities",
@@ -4540,7 +4484,7 @@ fn earn_opportunities_page(
     )
 }
 
-fn earn_earnings_page(data: &DashboardData, expires: u64, requested: Option<&str>) -> String {
+fn earn_earnings_page(data: &DashboardData, requested: Option<&str>) -> String {
     // Never use a query-selected provider as authority for earnings visibility.
     let provider_id = data.local_provider_id.as_deref();
     let rows = provider_earning_rows(data, provider_id);
@@ -4590,7 +4534,6 @@ fn earn_earnings_page(data: &DashboardData, expires: u64, requested: Option<&str
     );
     shell(
         data,
-        expires,
         DashboardAppPage::Earn,
         "Provider finance",
         "Earnings and payouts",
@@ -4604,7 +4547,6 @@ fn earn_earnings_page(data: &DashboardData, expires: u64, requested: Option<&str
 
 fn earn_reliability_page(
     data: &DashboardData,
-    expires: u64,
     requested: Option<&str>,
     requested_page: Option<&str>,
 ) -> String {
@@ -4653,7 +4595,6 @@ fn earn_reliability_page(
     let state = aggregate_provider_state(data, &entries);
     shell_wide(
         data,
-        expires,
         DashboardAppPage::Earn,
         "Provider quality",
         "Reliability",
@@ -4722,7 +4663,7 @@ fn provider_probation_summary(probation: Option<&ProviderProbation>) -> String {
     )
 }
 
-fn network_overview_page(data: &DashboardData, expires: u64) -> String {
+fn network_overview_page(data: &DashboardData) -> String {
     let providers = data
         .models
         .iter()
@@ -4802,10 +4743,10 @@ fn network_overview_page(data: &DashboardData, expires: u64) -> String {
     } else {
         ("Supply exceptions", "warn")
     };
-    shell_wide(data, expires, DashboardAppPage::Network, "Explore", "Network health", "Current provider capacity, route availability, market conditions, and supporting evidence.", status, tone, "", &content)
+    shell_wide(data, DashboardAppPage::Network, "Explore", "Network health", "Current provider capacity, route availability, market conditions, and supporting evidence.", status, tone, "", &content)
 }
 
-fn network_models_page(data: &DashboardData, expires: u64, requested_page: Option<&str>) -> String {
+fn network_models_page(data: &DashboardData, requested_page: Option<&str>) -> String {
     let page = PageWindow::from_query(data.models.len(), MAX_MODEL_ROWS, requested_page);
     let rows = model_rows(data, page);
     let model_summary = page.status("network models");
@@ -4828,7 +4769,6 @@ fn network_models_page(data: &DashboardData, expires: u64, requested_page: Optio
     );
     shell_wide(
         data,
-        expires,
         DashboardAppPage::Network,
         "Network analysis",
         "Models",
@@ -4848,11 +4788,7 @@ fn network_models_page(data: &DashboardData, expires: u64, requested_page: Optio
     )
 }
 
-fn network_providers_page(
-    data: &DashboardData,
-    expires: u64,
-    requested_page: Option<&str>,
-) -> String {
+fn network_providers_page(data: &DashboardData, requested_page: Option<&str>) -> String {
     let total_routes = data
         .models
         .iter()
@@ -4880,7 +4816,6 @@ fn network_providers_page(
     );
     shell_wide(
         data,
-        expires,
         DashboardAppPage::Network,
         "Network analysis",
         "Providers",
@@ -4900,11 +4835,7 @@ fn network_providers_page(
     )
 }
 
-fn network_markets_page(
-    data: &DashboardData,
-    expires: u64,
-    requested_page: Option<&str>,
-) -> String {
+fn network_markets_page(data: &DashboardData, requested_page: Option<&str>) -> String {
     let total_markets = data
         .models
         .iter()
@@ -4992,7 +4923,6 @@ fn network_markets_page(
     );
     shell_wide(
         data,
-        expires,
         DashboardAppPage::Network,
         "Network analysis",
         "Markets",
@@ -5004,11 +4934,7 @@ fn network_markets_page(
     )
 }
 
-fn network_activity_page(
-    data: &DashboardData,
-    expires: u64,
-    requested_page: Option<&str>,
-) -> String {
+fn network_activity_page(data: &DashboardData, requested_page: Option<&str>) -> String {
     let mut entries = data.entries.iter().collect::<Vec<_>>();
     entries.sort_by_key(|entry| entry.heartbeat_age_millis.unwrap_or(u64::MAX));
     let page = PageWindow::from_query(entries.len(), MAX_EVIDENCE_ROWS, requested_page);
@@ -5051,7 +4977,6 @@ fn network_activity_page(
     );
     shell_wide(
         data,
-        expires,
         DashboardAppPage::Network,
         "Network analysis",
         "Route status",
@@ -5065,7 +4990,6 @@ fn network_activity_page(
 
 fn network_evidence_page(
     data: &DashboardData,
-    expires: u64,
     requested_page: Option<&str>,
     requested_probe_page: Option<&str>,
 ) -> String {
@@ -5213,7 +5137,6 @@ fn network_evidence_page(
     );
     shell_wide(
         data,
-        expires,
         DashboardAppPage::Network,
         "Network analysis",
         "Evidence",
@@ -5225,7 +5148,7 @@ fn network_evidence_page(
     )
 }
 
-fn help_page(data: &DashboardData, expires: u64) -> String {
+fn help_page(data: &DashboardData) -> String {
     let provider_start = if data.local_provider_id.is_some() {
         r##"<a class="soft-button" href="/mayhem/dashboard/earn">Open Provider overview</a>"##
     } else {
@@ -5236,7 +5159,6 @@ fn help_page(data: &DashboardData, expires: u64) -> String {
     );
     shell(
         data,
-        expires,
         DashboardAppPage::Help,
         "Support",
         "Help",
@@ -5248,7 +5170,7 @@ fn help_page(data: &DashboardData, expires: u64) -> String {
     )
 }
 
-fn settings_page(data: &DashboardData, expires: u64) -> String {
+fn settings_page(data: &DashboardData) -> String {
     let github_update = data.github_update.update.as_ref();
     let (version_status, version_tone) = match (data.update_notice.as_ref(), github_update) {
         (Some(notice), _) if notice.level == "required" => ("Update required", "danger"),
@@ -5296,7 +5218,6 @@ fn settings_page(data: &DashboardData, expires: u64) -> String {
     );
     shell(
         data,
-        expires,
         DashboardAppPage::Settings,
         "Application",
         "Settings",
@@ -6994,7 +6915,7 @@ mod tests {
         let data = DashboardData::from_state(&state);
         assert_eq!(data.provider_heartbeat_ttl_millis, 4_321);
 
-        let html = earn_overview_page(&data, 60, None, None);
+        let html = earn_overview_page(&data, None, None);
         assert!(html.contains("Live route metrics"));
         assert!(html.contains("No routes yet"));
         assert!(!html.contains(">0 / 0<"));
@@ -7049,7 +6970,7 @@ mod tests {
             reason: "receipt co-signing stopped".to_owned(),
         });
 
-        let html = activity_page(&data, 60, None);
+        let html = activity_page(&data, None);
         let incomplete = html.find("session-incomplete").expect("incomplete receipt");
         let paused = html.find("session-paused").expect("pause record");
         let final_receipt = html.find("session-final").expect("final receipt");
@@ -7195,7 +7116,7 @@ mod tests {
             },
         );
 
-        let html = earn_machines_page(&data, 60, None, None);
+        let html = earn_machines_page(&data, None, None);
         assert!(html.contains("Setup blocked by model failure"));
         assert!(html.contains("Model preparation failed"));
         assert!(html.contains(
@@ -7209,7 +7130,7 @@ mod tests {
             r#"href="/mayhem/dashboard/earn/machines" aria-label="Refresh provider machine snapshot">Refresh snapshot"#
         ));
 
-        let overview = earn_overview_page(&data, 60, None, None);
+        let overview = earn_overview_page(&data, None, None);
         assert!(overview.contains("Setup blocked by model failure"));
         assert!(overview
             .contains("model-a: verify catalog artifact failed: artifact signature mismatch"));
@@ -7257,7 +7178,7 @@ mod tests {
             },
         );
 
-        let html = earn_machines_page(&data, 60, None, None);
+        let html = earn_machines_page(&data, None, None);
         assert!(html.contains("download progress not reported"));
         assert!(
             html.contains("<progress max=\"100\" aria-label=\"download progress not reported\">")
@@ -7271,7 +7192,6 @@ mod tests {
         let query = DashboardQuery::default();
         let home = render_dashboard_product_page(
             &state,
-            60,
             "http://127.0.0.1:11435",
             &query,
             DashboardProductPage::Home,
@@ -7281,7 +7201,6 @@ mod tests {
 
         let earn = render_dashboard_product_page(
             &state,
-            60,
             "http://127.0.0.1:11435",
             &query,
             DashboardProductPage::Earn,
@@ -7294,7 +7213,6 @@ mod tests {
 
         let opportunities = render_dashboard_product_page(
             &state,
-            60,
             "http://127.0.0.1:11435",
             &query,
             DashboardProductPage::EarnOpportunities,
@@ -7318,7 +7236,7 @@ mod tests {
             models: Vec::new(),
         });
 
-        let html = settings_page(&data, 60);
+        let html = settings_page(&data);
         assert!(html.contains("<code id=\"mayhem-update-stage-command\">mayhem update</code>"));
         assert!(html.contains("data-copy-target=\"#mayhem-update-stage-command\""));
         assert!(html.contains(
@@ -7356,7 +7274,7 @@ mod tests {
             update: Some(update),
         };
 
-        let html = settings_page(&data, 60);
+        let html = settings_page(&data);
         assert!(html.contains("Source update only."));
         assert!(html.contains("View changes on GitHub"));
         assert!(html.contains("data-update-notice"));
@@ -7392,7 +7310,7 @@ mod tests {
             update: Some(update),
         };
 
-        let html = settings_page(&data, 60);
+        let html = settings_page(&data);
         assert!(html.contains("0.3.0 available"));
         assert!(html.contains("Agent-guided update recommended."));
         assert!(html.contains("View release notes"));
@@ -7435,7 +7353,7 @@ mod tests {
         );
 
         let data = DashboardData::from_state(&GatewayState::from_models(Vec::new()));
-        let wallet = wallet_page(&data, 60);
+        let wallet = wallet_page(&data);
         assert!(wallet.contains("data-hide-amounts"));
         assert!(wallet.contains("Stripe is recommended"));
         assert!(wallet.contains("Agent-guided setup is recommended."));
@@ -7459,7 +7377,7 @@ mod tests {
 
         let tap_state = GatewayState::from_models(Vec::new()).with_receipt_rail("tap");
         let tap_data = DashboardData::from_state(&tap_state);
-        let tap_wallet = wallet_page(&tap_data, 60);
+        let tap_wallet = wallet_page(&tap_data);
         assert!(tap_wallet.contains(
             r#"data-wallet-method="tap"><input type="radio" name="wallet-funding-method" value="tap" data-wallet-funding-method checked"#
         ));
@@ -7467,7 +7385,7 @@ mod tests {
         assert!(tap_wallet.contains("Use this balance for requests"));
         assert!(tap_wallet.contains("mayhem up --rail fiat --yes"));
 
-        let settings = settings_page(&tap_data, 60);
+        let settings = settings_page(&tap_data);
         assert!(settings.contains(r#"id="wallet-security""#));
         assert!(settings.contains(r#"id="wallet-backup-command""#));
     }
@@ -7494,7 +7412,7 @@ mod tests {
     #[test]
     fn playground_no_script_explanation_precedes_and_hides_enhanced_fields() {
         let data = DashboardData::from_state(&GatewayState::fixture());
-        let html = playground_page(&data, 60, None);
+        let html = playground_page(&data, None);
         let warning = html.find("<noscript>").expect("no-JavaScript warning");
         let enhanced = html
             .find(r#"<div class="playground-interactive js-only">"#)
@@ -7508,7 +7426,7 @@ mod tests {
     #[test]
     fn playground_request_controls_match_gateway_routing_contracts() {
         let data = DashboardData::from_state(&GatewayState::fixture());
-        let html = playground_page(&data, 60, None);
+        let html = playground_page(&data, None);
 
         assert!(html.contains("data-playground-controls"));
         assert!(html.contains("Generation settings"));
@@ -7561,7 +7479,7 @@ mod tests {
         assert!(!config.sizes.values().any(|size| size == "512x512"));
 
         let data = DashboardData::from_state(&GatewayState::from_models(vec![model.clone()]));
-        let html = playground_page(&data, 60, Some(&model.id));
+        let html = playground_page(&data, Some(&model.id));
         assert!(html.contains(r#"data-image-dimension-mode="size""#));
         assert!(html.contains(r#"&quot;1:1&quot;:&quot;1024x1024&quot;"#));
         assert!(html.contains("data-playground-image-size"));
@@ -7582,7 +7500,7 @@ mod tests {
         fixed_model.mayhem.price_ref_au.per_req_au = AU_PER_USD;
         fixed_model.mayhem.price_ref_au.min_session_au = 2 * AU_PER_USD;
         let fixed_state = GatewayState::from_models(vec![fixed_model]);
-        let fixed_html = playground_page(&DashboardData::from_state(&fixed_state), 60, None);
+        let fixed_html = playground_page(&DashboardData::from_state(&fixed_state), None);
         assert!(fixed_html.contains(r#"data-price-mode="fixed""#));
 
         let mut mixed_model = GatewayState::fixture().models_snapshot()[0].clone();
@@ -7590,7 +7508,7 @@ mod tests {
         mixed_model.mayhem.price_ref_au.min_session_au = 2 * AU_PER_USD;
         assert!(!mixed_model.mayhem.price_ref_au.rate_map.is_empty());
         let mixed_state = GatewayState::from_models(vec![mixed_model]);
-        let mixed_html = playground_page(&DashboardData::from_state(&mixed_state), 60, None);
+        let mixed_html = playground_page(&DashboardData::from_state(&mixed_state), None);
         assert!(mixed_html.contains(r#"data-price-mode="rate""#));
         assert!(!mixed_html.contains(r#"data-price-mode="fixed""#));
     }
@@ -7602,13 +7520,13 @@ mod tests {
             "require_auth": true,
             "active_token_count": 0,
         });
-        let auth_html = playground_page(&credential_required, 60, None);
+        let auth_html = playground_page(&credential_required, None);
         assert!(auth_html.contains("<h1>Playground</h1>"));
         assert!(auth_html.contains("<h2>Create an access token first</h2>"));
         assert!(!auth_html.contains("<h3>Create an access token first</h3>"));
 
         let no_models = DashboardData::from_state(&GatewayState::from_models(Vec::new()));
-        let empty_html = playground_page(&no_models, 60, None);
+        let empty_html = playground_page(&no_models, None);
         assert!(empty_html.contains("<h1>Playground</h1>"));
         assert!(empty_html.contains("<h2>No compatible models available</h2>"));
         assert!(!empty_html.contains("<h3>No compatible models available</h3>"));
@@ -7668,13 +7586,13 @@ mod tests {
         }
 
         let user_only = DashboardData::from_state(&GatewayState::from_models(Vec::new()));
-        let user_html = home_page(&user_only, 60);
+        let user_html = home_page(&user_only);
         assert!(user_html.contains("<h2>Getting started</h2>"));
 
         let configured = GatewayState::from_models(Vec::new()).with_local_provider_id("provider-a");
         let provider_data = DashboardData::from_state(&configured);
         assert_eq!(provider_data.completed_requests(), 0);
-        let provider_html = home_page(&provider_data, 60);
+        let provider_html = home_page(&provider_data);
         assert!(provider_html.contains("<h2>Your provider</h2>"));
         assert!(!provider_html.contains("<h2>Getting started</h2>"));
     }
@@ -7697,7 +7615,7 @@ mod tests {
             },
         );
 
-        let html = home_page(&data, 60);
+        let html = home_page(&data);
         assert!(html.contains("Your provider"));
         assert!(html.contains("Setup blocked by model failure"));
         assert!(html.contains("artifact signature mismatch"));
@@ -7707,7 +7625,7 @@ mod tests {
     #[test]
     fn model_fit_keeps_its_evidence_limit_in_one_visible_consequence_statement() {
         let data = DashboardData::from_state(&GatewayState::fixture());
-        let html = earn_opportunities_page(&data, 60, None, None);
+        let html = earn_opportunities_page(&data, None, None);
 
         assert!(html.contains("<strong>Gateway-host evidence only.</strong>"));
         assert_eq!(html.matches("remote worker").count(), 1);
@@ -7750,7 +7668,7 @@ mod tests {
         assert!(omitted_abilities > 0);
         let state = GatewayState::from_models(vec![model]);
         let data = DashboardData::from_state(&state);
-        let html = models_page(&data, 60, None);
+        let html = models_page(&data, None);
 
         assert!(html.contains(&format!(
             r#"data-collapsed-label="+{omitted_abilities} more""#
@@ -7804,7 +7722,7 @@ mod tests {
         }];
         let mut data = DashboardData::from_state(&GatewayState::fixture());
         data.models = Arc::new(vec![model.clone()]);
-        let html = network_markets_page(&data, 60, None);
+        let html = network_markets_page(&data, None);
 
         assert!(html.contains(&format!(
             r#"data-export-value="{} / enclave {}""#,
@@ -7859,10 +7777,10 @@ mod tests {
     fn empty_tables_do_not_render_dead_subset_filters() {
         let data = DashboardData::from_state(&GatewayState::from_models(Vec::new()));
         for html in [
-            models_page(&data, 60, None),
-            activity_page(&data, 60, None),
-            network_providers_page(&data, 60, None),
-            network_markets_page(&data, 60, None),
+            models_page(&data, None),
+            activity_page(&data, None),
+            network_providers_page(&data, None),
+            network_markets_page(&data, None),
         ] {
             assert!(!html.contains("data-table-filter"));
             assert!(!html.contains("Filter shown page"));
@@ -7923,7 +7841,6 @@ mod tests {
 
         let current = connect_page(
             &DashboardData::from_state(&state),
-            60,
             "http://127.0.0.1:11435",
             None,
         );
@@ -7936,7 +7853,6 @@ mod tests {
         write_store(&token);
         let revoked = connect_page(
             &DashboardData::from_state(&state),
-            60,
             "http://127.0.0.1:11435",
             None,
         );
@@ -8022,7 +7938,6 @@ mod tests {
             .with_provider_earnings(vec![earnings_fixture("provider-from-url", amount)]);
         let html = render_dashboard_product_page(
             &unscoped,
-            60,
             "http://127.0.0.1:11435",
             &query,
             DashboardProductPage::EarnEarnings,
@@ -8036,7 +7951,6 @@ mod tests {
             .with_local_provider_id("provider-from-url");
         let html = render_dashboard_product_page(
             &scoped,
-            60,
             "http://127.0.0.1:11435",
             &query,
             DashboardProductPage::EarnEarnings,
@@ -8072,7 +7986,6 @@ mod tests {
 
         let html = render_dashboard_product_page(
             &state,
-            60,
             "http://127.0.0.1:11435",
             &DashboardQuery::default(),
             DashboardProductPage::Models,

--- a/crates/mayhem-gateway/src/openai/dashboard_ui.rs
+++ b/crates/mayhem-gateway/src/openai/dashboard_ui.rs
@@ -104,7 +104,6 @@ pub(super) struct DashboardShell<'a> {
     pub settings_update_badge: &'a str,
     pub content: &'a str,
     pub footer: &'a str,
-    pub expires_in_seconds: u64,
     pub wide: bool,
 }
 
@@ -178,7 +177,7 @@ pub(super) fn dashboard_app_shell(shell: DashboardShell<'_>) -> String {
   <div class="app-frame">
     <header class="app-topbar"><div class="topbar-context"><button class="icon-button mobile-menu-button js-only" type="button" data-nav-toggle aria-label="Open navigation" aria-controls="app-navigation" aria-expanded="false"><span aria-hidden="true">&#9776;</span></button><button class="icon-button sidebar-collapse-button js-only" type="button" data-sidebar-toggle aria-label="Collapse navigation" aria-controls="app-navigation" aria-expanded="true"><span aria-hidden="true">&#8592;</span></button><strong>{page_label}</strong><span class="topbar-status"><span class="state-indicator {status_tone}" aria-hidden="true"></span><span data-page-status-text>{status}</span></span></div><div class="topbar-actions">{topbar_update}{amount_control}</div></header>
     <main class="app-main{wide_class}{page_class}" id="main-content" tabindex="-1"><header class="page-head"><div><p class="page-eyebrow">{eyebrow}</p><h1>{heading}</h1><p class="page-summary">{summary}</p></div><div class="page-head-actions">{actions}</div></header>{content}</main>
-    <footer class="app-footer"><div class="app-footer-inner{wide_class_footer}"><span>{footer}</span><span class="mono" data-session-seconds="{expires}" data-session-status>Browser session active</span></div></footer>
+    <footer class="app-footer"><div class="app-footer-inner{wide_class_footer}"><span>{footer}</span><span class="mono">Authenticated for this gateway run</span></div></footer>
   </div>
 </div>
 <nav class="mobile-bottom-nav" aria-label="Mobile primary"><a href="/mayhem/dashboard"{mobile_home}>Home</a><a href="/mayhem/dashboard/playground"{mobile_playground}>Playground</a><a href="/mayhem/dashboard/activity"{mobile_activity}>Activity</a><a href="/mayhem/dashboard/earn"{mobile_earn}>Earn</a><a href="/mayhem/dashboard/wallet"{mobile_wallet}>Billing</a></nav>
@@ -227,7 +226,6 @@ pub(super) fn dashboard_app_shell(shell: DashboardShell<'_>) -> String {
         actions = shell.actions,
         content = shell.content,
         footer = html_escape(shell.footer),
-        expires = shell.expires_in_seconds,
         wide_class = if shell.wide { " app-main--wide" } else { "" },
         page_class = page_class,
         wide_class_footer = if shell.wide {
@@ -934,9 +932,6 @@ html.motion-reduced .pg-page *{animation-duration:.01ms!important;animation-iter
 .provider-scope{margin:-10px 0 18px}
 .provider-scope strong{color:var(--app-text-soft)}
 .table-action{white-space:nowrap}
-.session-expired{position:fixed;left:50%;bottom:max(24px,env(safe-area-inset-bottom));z-index:120;width:min(620px,calc(100vw - 28px));transform:translateX(-50%);padding:13px 14px;border:1px solid rgba(245,184,92,.44);border-radius:15px;background:#211b12;box-shadow:var(--app-shadow);color:var(--app-text);font-size:13px;display:flex;align-items:center;justify-content:space-between;gap:14px;pointer-events:none}
-.session-expired-copy{min-width:0}.session-expired-copy strong,.session-expired-copy span{display:block}.session-expired-copy span{margin-top:2px;color:var(--app-text-soft)}
-.session-expired-actions{display:flex;align-items:center;gap:8px;flex:0 0 auto}.session-expired-actions button{pointer-events:auto}
 
 .empty-block{min-height:190px;padding:28px;display:grid;place-items:center;text-align:center}
 .empty-block-inner{max-width:420px}
@@ -1031,7 +1026,6 @@ html.motion-reduced .pg-page *{animation-duration:.01ms!important;animation-iter
 .evidence-page-body .verify-level h2{margin:0 0 10px;font-size:15px}
 
 .toast-region{position:fixed;right:max(18px,env(safe-area-inset-right));bottom:max(18px,env(safe-area-inset-bottom));z-index:100;display:grid;gap:8px;pointer-events:none}
-body.session-expired-visible .toast-region{bottom:max(112px,calc(env(safe-area-inset-bottom) + 96px))}
 .app-toast{padding:11px 13px;border:1px solid var(--app-border-strong);border-radius:12px;background:var(--app-panel-strong);box-shadow:var(--app-shadow);color:var(--app-text);font-size:13px;animation:toast-in var(--app-standard) cubic-bezier(.2,0,.38,.9) both}
 @keyframes toast-in{from{opacity:0;transform:translateY(6px)}to{opacity:1;transform:none}}
 
@@ -1101,8 +1095,7 @@ body.session-expired-visible .toast-region{bottom:max(112px,calc(env(safe-area-i
   .app-footer{padding-inline:max(14px,env(safe-area-inset-left)) max(14px,env(safe-area-inset-right));padding-bottom:calc(max(18px,env(safe-area-inset-bottom)) + 78px)}
   .app-footer-inner{align-items:flex-start;flex-direction:column}
   html.js-ready .mobile-bottom-nav{position:fixed;left:max(10px,env(safe-area-inset-left));right:max(10px,env(safe-area-inset-right));bottom:max(10px,env(safe-area-inset-bottom));z-index:18;min-height:60px;padding:6px;border:1px solid var(--app-border);border-radius:18px;background:rgba(18,20,25,.95);box-shadow:0 16px 50px rgba(0,0,0,.38);backdrop-filter:blur(18px);display:grid;grid-template-columns:repeat(5,minmax(0,1fr));gap:3px}
-  .session-expired,.toast-region{bottom:calc(max(10px,env(safe-area-inset-bottom)) + 72px)}
-  body.session-expired-visible .toast-region{bottom:calc(max(10px,env(safe-area-inset-bottom)) + 206px)}
+  .toast-region{bottom:calc(max(10px,env(safe-area-inset-bottom)) + 72px)}
   .mobile-bottom-nav a,.mobile-bottom-nav button{min-width:0;border:0;border-radius:12px;background:transparent;color:var(--app-text-muted);display:grid;place-items:center;padding:8px 3px;text-decoration:none;font-size:12px;font-weight:700}
   .mobile-bottom-nav a[aria-current="page"],.mobile-bottom-nav button[aria-current="page"]{background:rgba(255,107,122,.11);color:var(--app-accent-strong)}
   html.js-ready .mobile-bottom-nav .js-only{display:grid!important}
@@ -1143,8 +1136,6 @@ body.session-expired-visible .toast-region{bottom:max(112px,calc(env(safe-area-i
   .launch-path-card>a{grid-column:1/-1;width:100%}
   .usage-bars{height:145px;gap:4px}
   .settings-row{grid-template-columns:1fr;align-items:start}
-  .session-expired{align-items:stretch;flex-direction:column}
-  .session-expired-actions{justify-content:flex-end}
   .verify-dialog{width:calc(100vw - 12px);max-height:calc(100dvh - 12px);border-radius:18px}
   .verify-head{padding:19px 62px 16px 18px}
   .verify-close{top:14px;right:14px}
@@ -1257,9 +1248,6 @@ pub(super) const DASHBOARD_APP_JS: &str = r##"
     const playgroundConversation = [];
     let drawerTrigger = null;
     let playgroundController = null;
-    let refreshDashboardSession = null;
-    let recordDashboardSessionActivity = null;
-
     const safeQuery = (selector, scope = document) => {
       if (!selector) return null;
       try { return scope.querySelector(selector); } catch (_) { return null; }
@@ -2259,13 +2247,10 @@ pub(super) const DASHBOARD_APP_JS: &str = r##"
           setConnectionResult(target, 'Workbench dashboard session is reachable. Production API credentials and inference are intentionally not exercised in preview.', 'good');
         } else {
           const response = await fetch('/mayhem/dashboard/session', { credentials: 'same-origin', cache: 'no-store' });
-          if (response.status === 401) throw new Error('Dashboard session expired');
+          if (response.status === 401) throw new Error('Dashboard access is not valid for this gateway run');
           if (!response.ok) throw new Error(`Gateway returned ${response.status}`);
           const data = await response.json();
           if (!data.ok) throw new Error('Gateway did not confirm readiness');
-          if (recordDashboardSessionActivity) {
-            recordDashboardSessionActivity(data.expires_in_seconds);
-          }
           setConnectionResult(target, 'Dashboard session is valid. Run an inference request from Playground to test the displayed API base URL, credential, and model route.', 'good');
         }
       } catch (error) {
@@ -3115,10 +3100,9 @@ pub(super) const DASHBOARD_APP_JS: &str = r##"
         try { payload = await response.json(); } catch (_) {}
         if (!response.ok || !payload || typeof payload !== 'object') {
           throw new Error(response.status === 401
-            ? 'This dashboard session expired. Reload the dashboard to continue.'
+            ? 'Dashboard access is not valid for this gateway run. Open the URL printed when Mayhem started.'
             : 'This evidence is no longer available in the current gateway snapshot.');
         }
-        if (recordDashboardSessionActivity) recordDashboardSessionActivity();
         title.textContent = typeof payload.title === 'string' ? payload.title : 'Evidence';
         const evidenceSummary = typeof payload.summary === 'string' ? payload.summary : 'Requested dashboard evidence';
         const evidenceInterpretation = typeof payload.interpretation === 'string' ? payload.interpretation : '';
@@ -3688,61 +3672,6 @@ pub(super) const DASHBOARD_APP_JS: &str = r##"
         return;
       }
 
-      if (event.target.closest('[data-session-extend]')) {
-        const button = event.target.closest('[data-session-extend]');
-        if (typeof refreshDashboardSession !== 'function') return;
-        button.disabled = true;
-        button.setAttribute('aria-busy', 'true');
-        refreshDashboardSession()
-          .then((renewed) => {
-            announce(
-              renewed
-                ? 'Dashboard session extended. You can continue on this page.'
-                : 'The session could not be extended. Your current page remains open.',
-              !renewed,
-              false
-            );
-          })
-          .finally(() => {
-            button.disabled = false;
-            button.removeAttribute('aria-busy');
-          });
-        return;
-      }
-
-      if (event.target.closest('[data-session-reload]')) {
-        const button = event.target.closest('[data-session-reload]');
-        if (typeof refreshDashboardSession !== 'function') {
-          window.location.reload();
-          return;
-        }
-        button.disabled = true;
-        button.setAttribute('aria-busy', 'true');
-        refreshDashboardSession()
-          .then((renewed) => {
-            if (!renewed) announce('Session still locked. Reopen the dashboard URL printed by mayhem up.', true);
-          })
-          .finally(() => {
-            button.disabled = false;
-            button.removeAttribute('aria-busy');
-          });
-        return;
-      }
-
-      if (event.target.closest('[data-session-dismiss]')) {
-        event.target.closest('[data-session-expired]')?.remove();
-        body.classList.remove('session-expired-visible');
-        body.dataset.sessionNoticeDismissed = 'true';
-        announce('Session notice dismissed');
-        return;
-      }
-
-      if (event.target.closest('[data-session-warning-dismiss]')) {
-        event.target.closest('[data-session-warning]')?.remove();
-        body.classList.remove('session-expired-visible');
-        body.dataset.sessionWarningDismissed = 'true';
-        announce('Session warning dismissed', false, false);
-      }
     });
 
     document.addEventListener('submit', (event) => {
@@ -3921,130 +3850,6 @@ pub(super) const DASHBOARD_APP_JS: &str = r##"
     mobileQuery.addEventListener('change', (event) => {
       if (!event.matches) setDrawer(false);
     });
-
-    const session = safeQuery('[data-session-seconds]');
-    if (session) {
-      const initial = Number.parseInt(session.getAttribute('data-session-seconds') || '', 10);
-      if (Number.isFinite(initial) && initial >= 0) {
-        let deadline = Date.now() + initial * 1000;
-        const clearSessionNotices = () => {
-          safeQuery('[data-session-expired]')?.remove();
-          safeQuery('[data-session-warning]')?.remove();
-          body.classList.remove('session-expired-visible');
-          delete body.dataset.sessionNoticeDismissed;
-          delete body.dataset.sessionWarningDismissed;
-        };
-        const showExpiryWarning = () => {
-          if (safeQuery('[data-session-warning]') || safeQuery('[data-session-expired]') || body.dataset.sessionWarningDismissed === 'true') return;
-          const notice = document.createElement('div');
-          notice.className = 'session-expired';
-          notice.dataset.sessionWarning = '';
-          notice.setAttribute('role', 'status');
-          notice.setAttribute('aria-live', 'polite');
-          notice.setAttribute('aria-atomic', 'true');
-          const copy = document.createElement('div');
-          copy.className = 'session-expired-copy';
-          const title = document.createElement('strong');
-          title.textContent = 'Dashboard session ends soon';
-          const help = document.createElement('span');
-          help.textContent = 'Extend access without reloading; this page, draft, filters, and scroll position stay in place.';
-          copy.append(title, help);
-          const actions = document.createElement('div');
-          actions.className = 'session-expired-actions';
-          const extend = document.createElement('button');
-          extend.className = 'soft-button';
-          extend.type = 'button';
-          extend.dataset.sessionExtend = '';
-          extend.textContent = 'Extend session';
-          const dismiss = document.createElement('button');
-          dismiss.className = 'quiet-button';
-          dismiss.type = 'button';
-          dismiss.dataset.sessionWarningDismiss = '';
-          dismiss.textContent = 'Dismiss';
-          actions.append(extend, dismiss);
-          notice.append(copy, actions);
-          body.classList.add('session-expired-visible');
-          document.body.appendChild(notice);
-        };
-        const showExpiredNotice = () => {
-          if (safeQuery('[data-session-expired]') || body.classList.contains('has-workbench') || body.dataset.sessionNoticeDismissed === 'true') return;
-          const notice = document.createElement('div');
-          notice.className = 'session-expired';
-          notice.dataset.sessionExpired = '';
-          notice.setAttribute('role', 'alert');
-          const copy = document.createElement('div');
-          copy.className = 'session-expired-copy';
-          const title = document.createElement('strong');
-          title.textContent = 'Dashboard session expired';
-          const help = document.createElement('span');
-          help.textContent = 'Reopen the dashboard URL printed by mayhem up, or retry after access was renewed in another tab.';
-          copy.append(title, help);
-          const actions = document.createElement('div');
-          actions.className = 'session-expired-actions';
-          const retry = document.createElement('button');
-          retry.className = 'soft-button';
-          retry.type = 'button';
-          retry.dataset.sessionReload = '';
-          retry.textContent = 'Retry access';
-          const dismiss = document.createElement('button');
-          dismiss.className = 'quiet-button';
-          dismiss.type = 'button';
-          dismiss.dataset.sessionDismiss = '';
-          dismiss.textContent = 'Dismiss';
-          actions.append(retry, dismiss);
-          notice.append(copy, actions);
-          body.classList.add('session-expired-visible');
-          document.body.appendChild(notice);
-        };
-        const tick = () => {
-          const remaining = Math.max(0, Math.ceil((deadline - Date.now()) / 1000));
-          const status = remaining > 60
-            ? 'Browser session active'
-            : remaining > 0
-              ? `Browser session · ${remaining}s remaining`
-              : 'Browser session expired';
-          if (session.textContent !== status) session.textContent = status;
-          if (remaining === 0) {
-            safeQuery('[data-session-warning]')?.remove();
-            body.classList.remove('session-expired-visible');
-            showExpiredNotice();
-          } else if (remaining <= 60) {
-            showExpiryWarning();
-          }
-        };
-        recordDashboardSessionActivity = (expiresInSeconds = initial) => {
-          const expires = Number.parseInt(String(expiresInSeconds), 10);
-          if (!Number.isFinite(expires) || expires <= 0) return;
-          deadline = Date.now() + expires * 1000;
-          session.setAttribute('data-session-seconds', String(expires));
-          clearSessionNotices();
-          tick();
-        };
-        refreshDashboardSession = async () => {
-          if (body.classList.contains('has-workbench')) {
-            recordDashboardSessionActivity(initial);
-            return true;
-          }
-          try {
-            const response = await fetch('/mayhem/dashboard/session', {
-              credentials: 'same-origin',
-              cache: 'no-store',
-              headers: { accept: 'application/json' }
-            });
-            if (!response.ok) return false;
-            const payload = await response.json();
-            const expires = Number.parseInt(String(payload?.expires_in_seconds ?? ''), 10);
-            if (!payload?.ok || !Number.isFinite(expires) || expires <= 0) return false;
-            recordDashboardSessionActivity(expires);
-            return true;
-          } catch (_) {
-            return false;
-          }
-        };
-        window.setInterval(tick, 1000);
-        tick();
-      }
-    }
 
     // Volatile evidence freshness: degrade only source-backed capacity/status
     // claims. Immutable receipt and catalog facts deliberately have no markers.

--- a/crates/mayhem-gateway/src/openai/dashboard_workbench.rs
+++ b/crates/mayhem-gateway/src/openai/dashboard_workbench.rs
@@ -333,7 +333,6 @@ async fn workbench_user(
     let origin = dashboard_origin_from_headers(&headers);
     let html = render_dashboard_product_page(
         &gateway,
-        3_600,
         &origin,
         &dashboard_query,
         DashboardProductPage::Home,
@@ -401,7 +400,6 @@ async fn workbench_provider(
     let origin = dashboard_origin_from_headers(&headers);
     let html = render_dashboard_product_page(
         &gateway,
-        3_600,
         &origin,
         &dashboard_query,
         DashboardProductPage::Earn,
@@ -420,7 +418,6 @@ async fn workbench_network(
     let origin = dashboard_origin_from_headers(&headers);
     let html = render_dashboard_product_page(
         &gateway,
-        3_600,
         &origin,
         &dashboard_query,
         DashboardProductPage::Network,
@@ -448,8 +445,7 @@ async fn workbench_product_page(
     let gateway = gateway_for_query(&state, scenario, &query);
     let dashboard_query = query.dashboard_query();
     let origin = dashboard_origin_from_headers(&headers);
-    let html =
-        render_dashboard_product_page(&gateway, 3_600, &origin, &dashboard_query, product_page);
+    let html = render_dashboard_product_page(&gateway, &origin, &dashboard_query, product_page);
     let base_path = format!("/mayhem/dashboard/{}", page.trim_matches('/'));
     workbench_product_response(html, scenario, &base_path)
 }

--- a/crates/mayhem-gateway/tests/dashboard-browser-smoke.mjs
+++ b/crates/mayhem-gateway/tests/dashboard-browser-smoke.mjs
@@ -732,17 +732,11 @@ try {
   await sessionPage.clock.install({ time: Date.now() });
   await sessionPage.goto(`${baseUrl}/mayhem/dashboard/playground?scenario=showcase`, { waitUntil: 'domcontentloaded' });
   await waitForDashboardReady(sessionPage);
-  const sessionSeconds = Number.parseInt(await sessionPage.locator('[data-session-seconds]').getAttribute('data-session-seconds') || '', 10);
-  check(Number.isFinite(sessionSeconds) && sessionSeconds > 60, 'session renewal', 'starts with a renewable browser session');
-  await sessionPage.locator('[data-playground-prompt]').fill('Keep this draft while extending the session.');
-  await sessionPage.clock.fastForward(Math.max(1, sessionSeconds - 59) * 1000);
-  const sessionWarning = sessionPage.locator('[data-session-warning]');
-  await sessionWarning.waitFor();
-  check(await sessionWarning.getByRole('button', { name: 'Extend session' }).isVisible(), 'session renewal', 'warns before the authentication cliff with an in-place action');
-  await sessionWarning.getByRole('button', { name: 'Extend session' }).click();
-  await sessionWarning.waitFor({ state: 'detached' });
-  equal(await sessionPage.locator('[data-playground-prompt]').inputValue(), 'Keep this draft while extending the session.', 'session renewal', 'preserves the active draft during renewal');
-  check((await sessionPage.locator('[data-session-seconds]').innerText()).includes('active'), 'session renewal', 'returns the visible session state to active');
+  check((await sessionPage.locator('.app-footer .mono').innerText()).includes('Authenticated for this gateway run'), 'gateway session', 'labels authentication as gateway-process scoped');
+  await sessionPage.locator('[data-playground-prompt]').fill('Keep this draft while the provider dashboard stays open.');
+  await sessionPage.clock.fastForward(2 * 24 * 60 * 60 * 1000);
+  check(await sessionPage.locator('[data-session-warning], [data-session-expired]').count() === 0, 'gateway session', 'does not introduce an idle authentication warning after two days');
+  equal(await sessionPage.locator('[data-playground-prompt]').inputValue(), 'Keep this draft while the provider dashboard stays open.', 'gateway session', 'preserves the active draft without session renewal');
   await sessionContext.close();
 
   const freshnessContext = await browser.newContext();

--- a/crates/mayhem-gateway/tests/openai_api.rs
+++ b/crates/mayhem-gateway/tests/openai_api.rs
@@ -1,6 +1,6 @@
 use axum::{
     body::{to_bytes, Body},
-    http::{HeaderMap, Method, Request, StatusCode},
+    http::{header, HeaderMap, Method, Request, StatusCode},
     Router,
 };
 use base64::Engine as _;
@@ -1587,6 +1587,35 @@ async fn raw_request_with_headers(
     (parts.status, parts.headers, bytes)
 }
 
+async fn dashboard_request_with_headers(
+    app: Router,
+    method: Method,
+    uri: &str,
+    body: Option<Value>,
+    request_headers: &[(&str, &str)],
+) -> (StatusCode, HeaderMap, Vec<u8>) {
+    let (status, headers, bytes) =
+        raw_request_with_headers(app.clone(), method, uri, body, request_headers).await;
+    if status != StatusCode::SEE_OTHER {
+        return (status, headers, bytes);
+    }
+
+    let location = headers
+        .get(header::LOCATION)
+        .and_then(|value| value.to_str().ok())
+        .expect("dashboard bootstrap redirect location")
+        .to_owned();
+    let cookie = headers
+        .get(header::SET_COOKIE)
+        .and_then(|value| value.to_str().ok())
+        .and_then(|value| value.split(';').next())
+        .expect("dashboard bootstrap cookie")
+        .to_owned();
+    let mut redirected_headers = request_headers.to_vec();
+    redirected_headers.push(("cookie", cookie.as_str()));
+    raw_request_with_headers(app, Method::GET, &location, None, &redirected_headers).await
+}
+
 async fn raw_bytes_request_with_headers(
     app: Router,
     method: Method,
@@ -1998,7 +2027,7 @@ async fn av3_ready_source_built_route_and_dashboard_report_local_policy_truth() 
         vec![provider.clone()]
     );
 
-    let (status, _, evidence_bytes) = raw_request_with_headers(
+    let (status, _, evidence_bytes) = dashboard_request_with_headers(
         app,
         Method::GET,
         &evidence_path,
@@ -2378,7 +2407,7 @@ async fn models_api_and_market_dashboard_share_selector_live_counts() {
     assert_eq!(market["route_count"], 1);
     assert_eq!(market["availability"], "routable");
 
-    let (status, _, bytes) = raw_request_with_headers(
+    let (status, _, bytes) = dashboard_request_with_headers(
         app.clone(),
         Method::GET,
         &market_path,
@@ -2412,7 +2441,7 @@ async fn models_api_and_market_dashboard_share_selector_live_counts() {
     assert_eq!(market["route_count"], 0);
     assert_eq!(market["availability"], "no_eligible_provider_yet");
 
-    let (status, _, bytes) = raw_request_with_headers(
+    let (status, _, bytes) = dashboard_request_with_headers(
         app,
         Method::GET,
         &market_path,
@@ -2550,7 +2579,7 @@ async fn models_endpoint_and_progressive_evidence_expose_speciality_cost_and_ava
         json!(["low"])
     );
 
-    let (status, _, user_bytes) = raw_request_with_headers(
+    let (status, _, user_bytes) = dashboard_request_with_headers(
         app.clone(),
         Method::GET,
         &user_path,
@@ -2563,7 +2592,7 @@ async fn models_endpoint_and_progressive_evidence_expose_speciality_cost_and_ava
     assert!(user_html.contains("reasoning_effort:low|high|xhigh"));
     assert!(user_html.contains("data-evidence-url"));
 
-    let (status, _, provider_bytes) = raw_request_with_headers(
+    let (status, _, provider_bytes) = dashboard_request_with_headers(
         app.clone(),
         Method::GET,
         &provider_path,
@@ -2577,7 +2606,7 @@ async fn models_endpoint_and_progressive_evidence_expose_speciality_cost_and_ava
     assert!(provider_html.contains("No machine routes yet"));
     assert!(!provider_html.contains("mayhem/routed-test"));
 
-    let (status, _, network_bytes) = raw_request_with_headers(
+    let (status, _, network_bytes) = dashboard_request_with_headers(
         app.clone(),
         Method::GET,
         &network_path,
@@ -2590,7 +2619,7 @@ async fn models_endpoint_and_progressive_evidence_expose_speciality_cost_and_ava
     assert!(network_html.contains("reasoning_effort:low|high|xhigh"));
     assert!(network_html.contains("data-evidence-url"));
 
-    let (status, _, evidence_bytes) = raw_request_with_headers(
+    let (status, _, evidence_bytes) = dashboard_request_with_headers(
         app,
         Method::GET,
         &evidence_path,
@@ -7512,22 +7541,59 @@ async fn dashboard_requires_token_sets_csp_and_serves_no_external_assets() {
     let locked = String::from_utf8(bytes).expect("locked dashboard html");
     assert_no_external_urls(&locked);
 
-    let (status, headers, bytes) =
-        raw_request(app.clone(), Method::GET, dashboard_path, None).await;
+    let (status, headers, _) = raw_request(app.clone(), Method::GET, dashboard_path, None).await;
+    assert_eq!(status, StatusCode::SEE_OTHER);
+    assert_eq!(
+        headers
+            .get(header::LOCATION)
+            .and_then(|value| value.to_str().ok()),
+        Some("/mayhem/dashboard")
+    );
+    let set_cookie = headers
+        .get(header::SET_COOKIE)
+        .and_then(|value| value.to_str().ok())
+        .expect("dashboard session cookie");
+    assert!(set_cookie.contains("Max-Age=34560000"));
+    assert!(set_cookie.contains("HttpOnly"));
+    assert!(set_cookie.contains("SameSite=Strict"));
+    let cookie = set_cookie
+        .split(';')
+        .next()
+        .expect("dashboard cookie pair")
+        .to_owned();
+
+    let (status, _, bytes) = raw_request_with_headers(
+        app.clone(),
+        Method::GET,
+        "/mayhem/dashboard",
+        None,
+        &[("cookie", &cookie)],
+    )
+    .await;
     assert_eq!(status, StatusCode::OK);
-    assert!(headers.get("set-cookie").is_some());
-    let body = String::from_utf8(bytes).expect("dashboard html");
+    let body = String::from_utf8(bytes).expect("dashboard html after bootstrap redirect");
     assert!(body.contains(r#"class="app-shell""#));
     assert!(body.contains(r#"href="/mayhem/dashboard/models""#));
     assert!(body.contains(r#"href="/mayhem/dashboard/network""#));
-    assert!(body.contains("Browser session"));
+    assert!(body.contains("Authenticated for this gateway run"));
     assert_no_external_urls(&body);
 
-    let cookie = headers
-        .get("set-cookie")
+    let filtered_path = format!("{dashboard_path}&page=2");
+    let (status, filtered_headers, _) =
+        raw_request(app.clone(), Method::GET, &filtered_path, None).await;
+    assert_eq!(status, StatusCode::SEE_OTHER);
+    assert_eq!(
+        filtered_headers
+            .get(header::LOCATION)
+            .and_then(|value| value.to_str().ok()),
+        Some("/mayhem/dashboard?page=2")
+    );
+    assert!(!filtered_headers
+        .get(header::LOCATION)
         .and_then(|value| value.to_str().ok())
-        .expect("dashboard session cookie")
-        .to_owned();
+        .unwrap_or_default()
+        .contains("token="));
+
     let (status, _, _) = raw_request_with_headers(
         app.clone(),
         Method::GET,
@@ -7562,13 +7628,29 @@ async fn dashboard_requires_token_sets_csp_and_serves_no_external_assets() {
     .await;
     assert_eq!(status, StatusCode::OK);
 
-    let session_path = format!("/mayhem/dashboard/session{query}");
-    let (status, body) = json_request(app, Method::GET, &session_path, Value::Null).await;
+    let (status, body) = json_request_with_headers(
+        app.clone(),
+        Method::GET,
+        "/mayhem/dashboard/session",
+        Value::Null,
+        &[("cookie", &cookie)],
+    )
+    .await;
     assert_eq!(status, StatusCode::OK);
     assert_eq!(body["ok"], true);
-    let expires = body["expires_in_seconds"].as_u64().expect("expiry seconds");
-    assert!(expires > 0);
-    assert!(expires <= 900);
+    assert_eq!(body["session_scope"], "gateway_process");
+    assert!(body.get("expires_in_seconds").is_none());
+
+    let restarted = openai_router(GatewayState::from_embedded_catalog());
+    let (status, _, _) = raw_request_with_headers(
+        restarted,
+        Method::GET,
+        "/mayhem/dashboard",
+        None,
+        &[("cookie", &cookie)],
+    )
+    .await;
+    assert_eq!(status, StatusCode::UNAUTHORIZED);
 }
 
 #[tokio::test]
@@ -7581,7 +7663,7 @@ async fn dashboard_uses_local_design_system_and_font_asset() {
     let app = openai_router(state);
 
     let (status, headers, bytes) =
-        raw_request(app.clone(), Method::GET, dashboard_path, None).await;
+        dashboard_request_with_headers(app.clone(), Method::GET, dashboard_path, None, &[]).await;
     assert_eq!(status, StatusCode::OK);
     let body = String::from_utf8(bytes).expect("dashboard html");
     for expected in [
@@ -7590,7 +7672,7 @@ async fn dashboard_uses_local_design_system_and_font_asset() {
         r#"class="app-shell""#,
         r#"class="app-brand""#,
         r#"class="state-indicator"#,
-        "data-session-status",
+        "Authenticated for this gateway run",
     ] {
         assert!(body.contains(expected), "missing {expected}");
     }
@@ -7688,7 +7770,7 @@ async fn user_dashboard_renders_live_gateway_data() {
         json_request(app.clone(), Method::POST, "/v1/chat/completions", request).await;
     assert_eq!(status, StatusCode::OK);
 
-    let (status, _, bytes) = raw_request_with_headers(
+    let (status, _, bytes) = dashboard_request_with_headers(
         app.clone(),
         Method::GET,
         dashboard_path,
@@ -7706,7 +7788,7 @@ async fn user_dashboard_renders_live_gateway_data() {
     assert!(!body.contains("1,240.00 TAP"));
     assert_no_external_urls(&body);
 
-    let (status, _, bytes) = raw_request_with_headers(
+    let (status, _, bytes) = dashboard_request_with_headers(
         app.clone(),
         Method::GET,
         &connect_path,
@@ -7721,7 +7803,7 @@ async fn user_dashboard_renders_live_gateway_data() {
     assert!(connect.contains("OPENAI_BASE_URL=http://127.0.0.1:11435/v1"));
     assert_no_external_urls(&connect);
 
-    let (status, _, bytes) = raw_request_with_headers(
+    let (status, _, bytes) = dashboard_request_with_headers(
         app,
         Method::GET,
         &models_path,
@@ -7749,7 +7831,7 @@ async fn models_dashboard_shows_canonical_route_count() {
     let models_path = dashboard_path.replacen("/mayhem/dashboard?", "/mayhem/dashboard/models?", 1);
     let app = openai_router(state);
 
-    let (status, _, bytes) = raw_request_with_headers(
+    let (status, _, bytes) = dashboard_request_with_headers(
         app,
         Method::GET,
         &models_path,
@@ -7789,7 +7871,7 @@ async fn dashboard_page_query_reaches_later_models_and_clamps_invalid_values() {
     let out_of_range_path = format!("{first_path}&page=999");
     let app = openai_router(state);
 
-    let (first_status, _, first_bytes) = raw_request_with_headers(
+    let (first_status, _, first_bytes) = dashboard_request_with_headers(
         app.clone(),
         Method::GET,
         &first_path,
@@ -7804,7 +7886,7 @@ async fn dashboard_page_query_reaches_later_models_and_clamps_invalid_values() {
     assert!(first.contains("Showing rows 1&ndash;25 of 82 catalog models. Page 1 of 4."));
     assert!(first.contains(r#"rel="next" href="/mayhem/dashboard/models?page=2""#));
 
-    let (status, _, second_bytes) = raw_request_with_headers(
+    let (status, _, second_bytes) = dashboard_request_with_headers(
         app.clone(),
         Method::GET,
         &second_path,
@@ -7820,7 +7902,7 @@ async fn dashboard_page_query_reaches_later_models_and_clamps_invalid_values() {
     assert!(second.contains("Showing rows 76&ndash;82 of 82 catalog models. Page 4 of 4."));
     assert!(second.contains(r#"rel="prev" href="/mayhem/dashboard/models?page=3""#));
 
-    let (_, _, invalid_bytes) = raw_request_with_headers(
+    let (_, _, invalid_bytes) = dashboard_request_with_headers(
         app.clone(),
         Method::GET,
         &invalid_path,
@@ -7832,7 +7914,7 @@ async fn dashboard_page_query_reaches_later_models_and_clamps_invalid_values() {
     assert!(invalid.contains("mayhem/page-000"));
     assert!(invalid.contains("Page 1 of 4."));
 
-    let (_, _, clamped_bytes) = raw_request_with_headers(
+    let (_, _, clamped_bytes) = dashboard_request_with_headers(
         app,
         Method::GET,
         &out_of_range_path,
@@ -7888,7 +7970,7 @@ async fn provider_dashboard_renders_routes_receipts_and_earnings() {
     assert_eq!(state.receipts().len(), 1);
     assert_eq!(state.receipts()[0].receipt.body.provider, provider);
 
-    let (status, _, bytes) = raw_request_with_headers(
+    let (status, _, bytes) = dashboard_request_with_headers(
         app.clone(),
         Method::GET,
         &earn_path,
@@ -7905,7 +7987,7 @@ async fn provider_dashboard_renders_routes_receipts_and_earnings() {
     assert!(body.contains("$1.75"));
     assert_no_external_urls(&body);
 
-    let (status, _, bytes) = raw_request_with_headers(
+    let (status, _, bytes) = dashboard_request_with_headers(
         app.clone(),
         Method::GET,
         &activity_path,
@@ -7920,7 +8002,7 @@ async fn provider_dashboard_renders_routes_receipts_and_earnings() {
     assert!(activity.contains("Final receipt"));
     assert_no_external_urls(&activity);
 
-    let (status, _, bytes) = raw_request_with_headers(
+    let (status, _, bytes) = dashboard_request_with_headers(
         app,
         Method::GET,
         &earnings_path,
@@ -7966,7 +8048,7 @@ async fn network_provider_dashboard_counts_multi_enclave_routes() {
     let provider_path = format!("/mayhem/dashboard/network/providers?{query}");
     let app = openai_router(state);
 
-    let (status, _, bytes) = raw_request_with_headers(
+    let (status, _, bytes) = dashboard_request_with_headers(
         app,
         Method::GET,
         &provider_path,
@@ -8023,7 +8105,7 @@ async fn provider_dashboard_renders_local_load_progress() {
     let provider_path = format!("/mayhem/dashboard/earn/machines?{query}");
     let app = openai_router(state);
 
-    let (status, _, bytes) = raw_request_with_headers(
+    let (status, _, bytes) = dashboard_request_with_headers(
         app,
         Method::GET,
         &provider_path,
@@ -8078,7 +8160,7 @@ async fn provider_dashboard_renders_progress_before_route_exists() {
     let provider_path = format!("/mayhem/dashboard/earn/machines?{query}");
     let app = openai_router(state);
 
-    let (status, _, bytes) = raw_request_with_headers(
+    let (status, _, bytes) = dashboard_request_with_headers(
         app,
         Method::GET,
         &provider_path,
@@ -8134,7 +8216,7 @@ async fn provider_dashboard_hides_stale_progress_before_route_exists() {
     let provider_path = format!("/mayhem/dashboard/earn?{query}");
     let app = openai_router(state);
 
-    let (status, _, bytes) = raw_request_with_headers(
+    let (status, _, bytes) = dashboard_request_with_headers(
         app,
         Method::GET,
         &provider_path,
@@ -8198,7 +8280,7 @@ async fn network_dashboard_renders_live_catalog_and_provider_state() {
     );
     let app = openai_router(state);
 
-    let (status, _, bytes) = raw_request_with_headers(
+    let (status, _, bytes) = dashboard_request_with_headers(
         app.clone(),
         Method::GET,
         &network_path,
@@ -8216,7 +8298,7 @@ async fn network_dashboard_renders_live_catalog_and_provider_state() {
     assert!(body.contains("mayhem/unavailable-test"));
     assert_no_external_urls(&body);
 
-    let (status, _, bytes) = raw_request_with_headers(
+    let (status, _, bytes) = dashboard_request_with_headers(
         app.clone(),
         Method::GET,
         &network_models_path,
@@ -8233,7 +8315,7 @@ async fn network_dashboard_renders_live_catalog_and_provider_state() {
     assert!(models.contains("No provider route"));
     assert_no_external_urls(&models);
 
-    let (status, _, bytes) = raw_request_with_headers(
+    let (status, _, bytes) = dashboard_request_with_headers(
         app,
         Method::GET,
         &network_providers_path,

--- a/scripts/dashboard-workbench-smoke.mjs
+++ b/scripts/dashboard-workbench-smoke.mjs
@@ -1267,33 +1267,14 @@ async function exerciseWorkbench(baseUrl, options) {
   } catch (error) {
     report.check(false, 'app script', 'executes focused Playground contract helpers', error.message);
   }
-  report.includes(appJs.text, '[data-session-seconds]', 'app script', 'wires the live session timer');
-  report.includes(appJs.text, 'Dashboard session ends soon', 'app script', 'announces session expiry before access is lost');
-  report.includes(appJs.text, "extend.dataset.sessionExtend = ''", 'app script', 'offers a low-noise session extension action');
-  report.includes(
-    appJs.text,
-    'recordDashboardSessionActivity(initial);',
-    'app script',
-    'renews the fixture session in place so the warning path is behaviorally testable',
-  );
-  report.includes(
-    appJs.text,
-    'this page, draft, filters, and scroll position stay in place',
-    'app script',
-    'explains that extension preserves task context',
-  );
+  report.check(!appJs.text.includes('[data-session-seconds]'), 'app script', 'does not run an idle authentication timer');
+  report.check(!appJs.text.includes('recordDashboardSessionActivity'), 'app script', 'does not require in-place session renewal');
   report.includes(appJs.text, 'Export shown page', 'app script', 'labels CSV export as page-local');
   report.includes(appJs.text, 'tableToolParameter', 'app script', 'isolates query state for multiple tables on one page');
-  report.includes(
-    appJs.text,
-    'recordDashboardSessionActivity',
-    'app script',
-    'synchronizes the timer after user-triggered authenticated requests',
-  );
   report.check(
     !appJs.text.includes("document.addEventListener('visibilitychange'"),
     'app script',
-    'does not keep an idle browser session alive through passive visibility polling',
+    'does not add passive authentication polling',
   );
   report.includes(appJs.text, '[data-preference]', 'app script', 'wires saved presentation preferences');
 
@@ -1374,8 +1355,8 @@ async function exerciseWorkbench(baseUrl, options) {
           : 'omits the no-op amount-visibility control when no monetary values are present',
       );
       report.includes(response.text, `<strong>${route.pageLabel}</strong>`, scope, 'labels the current product area');
-      report.includes(response.text, 'data-session-seconds', scope, 'renders the session timer hook');
-      report.includes(response.text, 'data-session-status', scope, 'renders the session status hook');
+      report.includes(response.text, 'Authenticated for this gateway run', scope, 'labels the process-scoped browser session');
+      report.check(!response.text.includes('data-session-seconds'), scope, 'does not render an idle session timer');
       report.includes(response.text, 'aria-label="Mobile primary"', scope, 'renders labeled mobile navigation');
       if (MOBILE_MORE_ROUTE_IDS.has(route.id)) {
         report.includes(


### PR DESCRIPTION
## Summary

- replace the dashboard's 15-minute sliding idle session with authorization scoped to the running gateway process
- exchange the printed startup token for a persistent HttpOnly, SameSite=Strict browser cookie, then redirect to a clean URL without the token
- keep the browser authenticated across long idle periods and browser restarts while the gateway remains running; rotating the gateway process invalidates the old cookie
- remove expiry warnings, renewal controls, timer code, and timeout-oriented CLI output while preserving the existing startup copy/paste URLs (no new retrieval command)
- update integration, UI, static smoke, browser smoke, CLI, and documentation coverage
- keep generated test reports, traces, coverage data, profiler output, and temporary snapshots out of Git

## Security behavior

The browser cookie is persistent for the longest broadly supported browser window (400 days) and refreshed by authenticated dashboard responses. The server-side browser token remains in process memory and is authoritative, so a gateway restart immediately rejects cookies issued by the previous process. The dashboard remains loopback-only by default, and the cookie remains HttpOnly and SameSite=Strict.

## Verification

Re-run after rebasing onto current `main` (`v0.2.38`):

- `cargo fmt --all -- --check`
- `cargo test -p mayhem-gateway --features dashboard-workbench dashboard -- --nocapture` (51 unit/workbench + 14 API dashboard tests)
- `cargo test -p mayhem-cli read_up_logged_dashboard_url_returns_tokenized_copy_paste_url`
- `node scripts/dashboard-workbench-smoke.mjs --no-build --timeout-ms 30000` (10,905 assertions)
- `node crates/mayhem-gateway/tests/dashboard-browser-smoke.mjs --base-url <isolated-workbench>` (1,623 assertions; includes a two-day idle simulation)

Also passed before the rebase (the touched authentication code applied cleanly):

- `cargo check -p mayhem-gateway --features dashboard-workbench`
- `cargo check -p mayhem-cli`
- `cargo clippy -p mayhem-gateway --features dashboard-workbench --all-targets -- -D clippy::correctness -D clippy::suspicious`

## Existing workspace issue

The repository-wide Clippy command reports pre-existing `clippy::permissions_set_readonly_false` errors in `mayhem-enclave` and `mayhem-engine`. The scoped gateway Clippy command above passes, and this PR does not touch those files.
