### PR TITLE
Fix Playground generation controls

### DIFF
--- a/crates/mayhem-gateway/src/openai/dashboard_pages.rs
+++ b/crates/mayhem-gateway/src/openai/dashboard_pages.rs
@@ -2390,6 +2390,7 @@ fn playground_numeric_parameter(
     help: &str,
 ) -> Option<Value> {
     let spec = contract.request_attribute_specs.get(key)?;
+    let default = default.or_else(|| spec.default.as_ref().and_then(Value::as_f64));
     Some(json!({
         "key": key,
         "label": label,
@@ -2404,13 +2405,41 @@ fn playground_numeric_parameter(
         "section": section,
         "minimum": spec.minimum,
         "maximum": spec.maximum,
+        "multipleOf": spec.multiple_of,
         "step": step,
-        "default": default.or_else(|| spec.default.as_ref().and_then(Value::as_f64)),
+        "default": default,
+        "defaultSource": default.map(|_| "model"),
         "help": help,
     }))
 }
 
-fn playground_text_parameter_schema(model: &GatewayModel) -> Value {
+fn playground_parameter_option_label(value: &str) -> String {
+    match value {
+        "enabled" | "on" | "true" => "On".to_owned(),
+        "disabled" | "off" | "false" => "Off".to_owned(),
+        "latest_only" => "Latest only".to_owned(),
+        "preserve" => "Preserve".to_owned(),
+        _ => value
+            .split(['_', '-'])
+            .filter(|part| !part.is_empty())
+            .enumerate()
+            .map(|(index, part)| {
+                if index == 0 {
+                    let mut chars = part.chars();
+                    chars
+                        .next()
+                        .map(|first| first.to_uppercase().collect::<String>() + chars.as_str())
+                        .unwrap_or_default()
+                } else {
+                    part.to_owned()
+                }
+            })
+            .collect::<Vec<_>>()
+            .join(" "),
+    }
+}
+
+fn playground_text_parameter_schema(data: &DashboardData, model: &GatewayModel) -> Value {
     let Some(contract) = model
         .mayhem
         .adapter
@@ -2419,7 +2448,7 @@ fn playground_text_parameter_schema(model: &GatewayModel) -> Value {
         .find(|contract| contract.family == mayhem_proto::ENDPOINT_OPENAI_CHAT_COMPLETIONS)
     else {
         return json!({
-            "version": 1,
+            "version": 2,
             "contextTokens": model.mayhem.caps.ctx,
             "contextLabel": format_token_count(u64::from(model.mayhem.caps.ctx)),
             "controls": [],
@@ -2428,25 +2457,96 @@ fn playground_text_parameter_schema(model: &GatewayModel) -> Value {
 
     let mut controls = Vec::new();
     if let Some(spec) = contract.request_attribute_specs.get("max_tokens") {
-        let maximum = spec.maximum.unwrap_or(4_096.0).clamp(1.0, 4_096.0);
-        let contract_minimum = spec.minimum.unwrap_or(1.0).clamp(1.0, maximum);
-        let minimum = if maximum >= 64.0 {
-            contract_minimum.max(64.0)
-        } else {
-            contract_minimum
-        };
-        let default = 512_f64.clamp(minimum, maximum);
-        controls.push(json!({
-            "key": "max_tokens",
-            "label": "Output limit",
-            "kind": "integer",
-            "section": "primary",
-            "minimum": minimum,
-            "maximum": maximum,
-            "step": if maximum >= 64.0 { 64 } else { 1 },
-            "default": default,
-            "help": "Maximum tokens generated for this response. The model can finish sooner.",
-        }));
+        let context_maximum = f64::from(model.mayhem.caps.ctx);
+        let maximum = spec
+            .maximum
+            .filter(|value| value.is_finite() && *value >= 0.0)
+            .unwrap_or(context_maximum)
+            .min(context_maximum)
+            .min(f64::from(u32::MAX))
+            .floor();
+        let minimum = spec
+            .minimum
+            .filter(|value| value.is_finite() && *value >= 0.0)
+            .unwrap_or(0.0)
+            .ceil();
+        if minimum <= maximum {
+            let contract_default = spec
+                .default
+                .as_ref()
+                .and_then(Value::as_f64)
+                .filter(|value| value.is_finite());
+            let default = contract_default.unwrap_or(512.0).clamp(minimum, maximum);
+            controls.push(json!({
+                "key": "max_tokens",
+                "label": "Output limit",
+                "kind": "integer",
+                "section": "primary",
+                "minimum": minimum,
+                "maximum": maximum,
+                "multipleOf": spec.multiple_of,
+                "step": spec.multiple_of.unwrap_or(1.0),
+                "default": default,
+                "defaultSource": if contract_default.is_some() { "model" } else { "playground" },
+                "help": "Maximum response tokens. The model may stop sooner; conversation input and thinking share the context window.",
+            }));
+        }
+    }
+
+    if let Some(spec) = contract.request_attribute_specs.get("thinking_mode") {
+        let speciality_availability =
+            gateway_speciality_availability(model, &data.entries, &data.live_route_keys);
+        let availability = speciality_availability.get("thinking_mode");
+        let model_default = spec
+            .default
+            .as_ref()
+            .and_then(Value::as_str)
+            .map(str::to_owned)
+            .or_else(|| availability.map(|value| value.default_level.clone()));
+        let mut options = Vec::new();
+        if let Some(default) = model_default.as_deref() {
+            let level = availability.and_then(|value| value.levels.get(default));
+            options.push(json!({
+                "value": "",
+                "label": format!("Model default ({})", playground_parameter_option_label(default)),
+                "available": level.map(|value| value.available),
+                "canonicalProviderCount": level.map(|value| value.canonical_provider_count),
+                "liveProviderCount": level.map(|value| value.live_provider_count),
+                "maxReasoningTokens": level.and_then(|value| value.max_reasoning_tokens),
+            }));
+        }
+        options.extend(
+            spec.enum_values
+                .iter()
+                .filter_map(Value::as_str)
+                .map(|value| {
+                    let level =
+                        availability.and_then(|availability| availability.levels.get(value));
+                    json!({
+                        "value": value,
+                        "label": playground_parameter_option_label(value),
+                        "available": level.map(|value| value.available),
+                        "canonicalProviderCount": level.map(|value| value.canonical_provider_count),
+                        "liveProviderCount": level.map(|value| value.live_provider_count),
+                        "maxReasoningTokens": level.and_then(|value| value.max_reasoning_tokens),
+                    })
+                })
+                .collect::<Vec<_>>(),
+        );
+        if !options.is_empty() {
+            controls.push(json!({
+                "key": "thinking_mode",
+                "label": "Thinking",
+                "kind": "select",
+                "speciality": true,
+                "section": "primary",
+                "default": if model_default.is_some() { Some("") } else { spec.default.as_ref().and_then(Value::as_str) },
+                "defaultSource": "model",
+                "modelDefault": model_default,
+                "options": options,
+                "help": "Choose the model default or require an exact thinking mode. The gateway never silently downgrades this choice.",
+            }));
+        }
     }
 
     if let Some(control) = playground_numeric_parameter(
@@ -2459,31 +2559,6 @@ fn playground_text_parameter_schema(model: &GatewayModel) -> Value {
         "Lower values are more focused. Higher values introduce more variation.",
     ) {
         controls.push(control);
-    }
-
-    if let Some(spec) = contract.request_attribute_specs.get("thinking_mode") {
-        let options = spec
-            .enum_values
-            .iter()
-            .filter_map(Value::as_str)
-            .map(|value| {
-                json!({
-                    "value": value,
-                    "label": if value == "enabled" { "On" } else { "Off" },
-                })
-            })
-            .collect::<Vec<_>>();
-        if !options.is_empty() {
-            controls.push(json!({
-                "key": "thinking_mode",
-                "label": "Thinking",
-                "kind": "select",
-                "section": "primary",
-                "default": spec.default.as_ref().and_then(Value::as_str),
-                "options": options,
-                "help": "Use the model's reasoning mode when the signed contract supports it.",
-            }));
-        }
     }
 
     for (key, label, step, default, help) in [
@@ -2522,13 +2597,6 @@ fn playground_text_parameter_schema(model: &GatewayModel) -> Value {
             model.mayhem.sampling.frequency_penalty,
             "Discourages repeating tokens in proportion to how often they appeared.",
         ),
-        (
-            "repeat_penalty",
-            "Repeat penalty",
-            0.05,
-            model.mayhem.sampling.repeat_penalty,
-            "Applies the model's native repetition penalty when supported.",
-        ),
     ] {
         if let Some(control) =
             playground_numeric_parameter(contract, key, label, "advanced", step, default, help)
@@ -2560,33 +2628,58 @@ fn playground_text_parameter_schema(model: &GatewayModel) -> Value {
             "kind": "lines",
             "section": "advanced",
             "default": Value::Null,
-            "help": "Optional. Enter one sequence per line, up to four sequences.",
+            "help": "Optional. Enter one sequence per line, up to four sequences of 1,024 characters each.",
         }));
     }
 
     if let Some(spec) = contract.request_attribute_specs.get("thinking_history") {
-        let options = spec
-            .enum_values
-            .iter()
-            .filter_map(Value::as_str)
-            .map(|value| {
-                json!({
-                    "value": value,
-                    "label": match value {
-                        "latest_only" => "Latest only",
-                        "preserve" => "Preserve",
-                        _ => value,
-                    },
+        let speciality_availability =
+            gateway_speciality_availability(model, &data.entries, &data.live_route_keys);
+        let availability = speciality_availability.get("thinking_history");
+        let model_default = spec
+            .default
+            .as_ref()
+            .and_then(Value::as_str)
+            .map(str::to_owned)
+            .or_else(|| availability.map(|value| value.default_level.clone()));
+        let mut options = Vec::new();
+        if let Some(default) = model_default.as_deref() {
+            let level = availability.and_then(|value| value.levels.get(default));
+            options.push(json!({
+                "value": "",
+                "label": format!("Model default ({})", playground_parameter_option_label(default)),
+                "available": level.map(|value| value.available),
+                "canonicalProviderCount": level.map(|value| value.canonical_provider_count),
+                "liveProviderCount": level.map(|value| value.live_provider_count),
+            }));
+        }
+        options.extend(
+            spec.enum_values
+                .iter()
+                .filter_map(Value::as_str)
+                .map(|value| {
+                    let level =
+                        availability.and_then(|availability| availability.levels.get(value));
+                    json!({
+                        "value": value,
+                        "label": playground_parameter_option_label(value),
+                        "available": level.map(|value| value.available),
+                        "canonicalProviderCount": level.map(|value| value.canonical_provider_count),
+                        "liveProviderCount": level.map(|value| value.live_provider_count),
+                    })
                 })
-            })
-            .collect::<Vec<_>>();
+                .collect::<Vec<_>>(),
+        );
         if !options.is_empty() {
             controls.push(json!({
                 "key": "thinking_history",
                 "label": "Thinking history",
                 "kind": "select",
+                "speciality": true,
                 "section": "advanced",
-                "default": spec.default.as_ref().and_then(Value::as_str),
+                "default": if model_default.is_some() { Some("") } else { spec.default.as_ref().and_then(Value::as_str) },
+                "defaultSource": "model",
+                "modelDefault": model_default,
                 "options": options,
                 "help": "Controls whether earlier reasoning state is replayed in a conversation.",
             }));
@@ -2594,7 +2687,7 @@ fn playground_text_parameter_schema(model: &GatewayModel) -> Value {
     }
 
     json!({
-        "version": 1,
+        "version": 2,
         "contextTokens": model.mayhem.caps.ctx,
         "contextLabel": format_token_count(u64::from(model.mayhem.caps.ctx)),
         "controls": controls,
@@ -2682,8 +2775,8 @@ fn playground_page(data: &DashboardData, selected_model: Option<&str>) -> String
                 )
             });
         let parameter_schema = html_escape(
-            &serde_json::to_string(&playground_text_parameter_schema(model))
-                .unwrap_or_else(|_| r#"{"version":1,"controls":[]}"#.to_owned()),
+            &serde_json::to_string(&playground_text_parameter_schema(data, model))
+                .unwrap_or_else(|_| r#"{"version":2,"controls":[]}"#.to_owned()),
         );
         options.push_str(&format!(
             r##"<option value="{}" data-playground-mode="{mode}" data-availability="{}" data-price="{}" data-price-mode="{price_mode}" data-location="Network provider route" data-protection="{}" data-context="Up to {context} catalog tokens" data-model-name="{}" data-model-lab="{}" data-model-purpose="{purpose}" data-parameter-schema="{parameter_schema}"{image_attributes}{selected}>{} &mdash; {}</option>"##,
@@ -2844,13 +2937,14 @@ fn playground_page(data: &DashboardData, selected_model: Option<&str>) -> String
 
     <button class="pg-controls-backdrop" type="button" data-playground-controls-backdrop aria-label="Close generation settings" hidden></button>
     <aside class="pg-controls" data-playground-controls aria-label="Generation settings">
-      <button class="pg-controls-toggle" type="button" data-playground-controls-toggle aria-expanded="false" aria-controls="playground-controls-body"><svg viewBox="0 0 24 24" aria-hidden="true"><path d="M4 7h10M18 7h2M14 4v6M4 17h2M10 17h10M10 14v6"/></svg><span class="pg-controls-toggle-copy"><strong>Generation settings</strong><small data-playground-controls-state>Model defaults</small></span><svg class="pg-controls-chevron" viewBox="0 0 24 24" aria-hidden="true"><path d="m9 18 6-6-6-6"/></svg></button>
+      <button class="pg-controls-toggle" type="button" data-playground-controls-toggle aria-expanded="false" aria-controls="playground-controls-body"><svg viewBox="0 0 24 24" aria-hidden="true"><path d="M4 7h10M18 7h2M14 4v6M4 17h2M10 17h10M10 14v6"/></svg><span class="pg-controls-toggle-copy"><strong>Generation settings</strong><small data-playground-controls-state>Defaults</small></span><svg class="pg-controls-chevron" viewBox="0 0 24 24" aria-hidden="true"><path d="m9 18 6-6-6-6"/></svg></button>
       <div class="pg-controls-body" id="playground-controls-body" data-playground-controls-body hidden>
         <header class="pg-controls-head"><div class="pg-controls-heading"><strong>Generation settings</strong><span><i aria-hidden="true"></i><span data-playground-controls-model>{default_model_name}</span></span></div><span class="pg-controls-head-actions"><button type="button" data-playground-reset-model aria-label="Reset generation settings for selected model" title="Reset model settings"><svg viewBox="0 0 24 24" aria-hidden="true"><path d="M4 4v6h6M20 20v-6h-6"/><path d="M5.1 15a8 8 0 0 0 13.2 2M18.9 9A8 8 0 0 0 5.7 7"/></svg><span>Reset</span></button><button type="button" data-playground-controls-close aria-label="Close generation settings"><svg viewBox="0 0 24 24" aria-hidden="true"><path d="m6 6 12 12M18 6 6 18"/></svg><span class="sr-only">Close generation settings</span></button></span></header>
         <div class="pg-controls-scroll">
-          <div class="pg-context-card"><span>Context window</span><strong data-playground-context-value>Checking catalog</strong><small>Read-only model limit</small></div>
+          <div class="pg-context-card"><span>Context window</span><strong data-playground-context-value>Checking catalog</strong><span>Maximum output</span><strong data-playground-output-maximum>Checking contract</strong><small>Conversation input, history, thinking, and output share the context window. The gateway confirms the exact fit when you send.</small></div>
+          <p class="pg-settings-note" data-playground-settings-note role="status" hidden></p>
           <div class="pg-control-group" data-playground-parameter-section="primary"></div>
-          <details class="pg-control-disclosure" data-playground-more-settings><summary><span><strong>More settings</strong><small>Sampling and instructions</small></span><svg viewBox="0 0 24 24" aria-hidden="true"><path d="m7 10 5 5 5-5"/></svg></summary><div class="pg-control-disclosure-body"><label class="pg-control-field span-all" for="playground-system"><span>System instructions <em>Text only</em></span><textarea id="playground-system" data-playground-system data-playground-draft rows="3" placeholder="Optional guidance for the model"></textarea><small>Saved only for this browser tab.</small></label><div class="pg-control-group pg-control-group-advanced" data-playground-parameter-section="advanced"></div></div></details>
+          <details class="pg-control-disclosure" data-playground-more-settings><summary><span><strong>Advanced</strong><small>Optional controls</small></span><svg viewBox="0 0 24 24" aria-hidden="true"><path d="m7 10 5 5 5-5"/></svg></summary><div class="pg-control-disclosure-body"><label class="pg-control-field span-all" for="playground-system"><span>System instructions <em>Text only</em></span><textarea id="playground-system" data-playground-system data-playground-draft rows="3" placeholder="Optional guidance for the model"></textarea><small>Saved only for this browser tab.</small></label><div class="pg-control-group pg-control-group-advanced" data-playground-parameter-section="advanced"></div></div></details>
           <details class="pg-control-disclosure" data-playground-routing-settings><summary><span><strong>Routing and trust</strong><small>Gateway limits</small></span><svg viewBox="0 0 24 24" aria-hidden="true"><path d="m7 10 5 5 5-5"/></svg></summary><div class="pg-control-disclosure-body">{token_field}<label class="pg-control-field" for="playground-max-price"><span><span data-playground-price-label>Route price ceiling</span><em data-playground-price-unit>USD</em></span><input id="playground-max-price" data-playground-max-price data-playground-draft data-money-input type="text" inputmode="decimal" autocomplete="off" spellcheck="false" pattern="[0-9]+([.][0-9]{{1,18}})?" placeholder="Optional USD ceiling"></label><label class="pg-control-field" for="playground-min-att-tier"><span>Minimum attestation tier</span><select id="playground-min-att-tier" data-playground-min-att-tier data-playground-draft><option value="">Gateway default</option><option value="1">At least T1 numerically</option><option value="2">At least T2 numerically</option><option value="3">At least T3 numerically</option><option value="4">T4 only</option></select><small>Numeric tier does not promise confidential compute.</small></label><div class="preflight span-all" data-playground-preflight><span><strong>Capacity:</strong> <span data-preflight-value="availability">Checking</span></span><span><strong>Protection:</strong> <span data-preflight-value="protection">Checking catalog</span></span><span><strong>Context:</strong> <span data-preflight-value="context">Checking catalog</span></span><span><strong>Catalog rates:</strong> <span class="money-value" data-money data-preflight-value="price">Unavailable</span></span></div></div></details>
           <button class="pg-text-action pg-controls-reset-all" type="button" data-playground-reset-draft>Reset Playground</button>
         </div>
@@ -7432,8 +7526,10 @@ mod tests {
         assert!(html.contains("Generation settings"));
         assert!(html.contains("data-playground-parameter-section=\"primary\""));
         assert!(html.contains("data-parameter-schema="));
+        assert!(html.contains("&quot;version&quot;:2"));
         assert!(html.contains("&quot;key&quot;:&quot;max_tokens&quot;"));
-        assert!(html.contains("&quot;maximum&quot;:4096.0"));
+        assert!(html.contains("&quot;defaultSource&quot;:&quot;playground&quot;"));
+        assert!(!html.contains("&quot;key&quot;:&quot;repeat_penalty&quot;"));
         assert!(html.contains("data-playground-max-price"));
         assert!(html.contains(r#"data-price-mode="rate""#));
         assert!(html.contains("data-money-input"));
@@ -7443,9 +7539,53 @@ mod tests {
         assert!(html.contains("Numeric tier does not promise confidential compute."));
         assert!(html.contains("data-playground-controls-state"));
         assert!(html.contains("Context window"));
+        assert!(html.contains("Maximum output"));
+        assert!(html.contains("Conversation input, history, thinking, and output share"));
         assert!(html.contains("drafts and history stay in this browser tab"));
         assert!(html.contains("access tokens are never saved"));
         assert!(html.contains("data-playground-reset-draft"));
+    }
+
+    #[test]
+    fn playground_output_limit_uses_the_full_signed_model_boundary() {
+        let mut model = GatewayState::fixture().models_snapshot()[0].clone();
+        model.mayhem.caps.ctx = 262_144;
+        let contract = model
+            .mayhem
+            .adapter
+            .endpoint_families
+            .iter_mut()
+            .find(|contract| contract.family == mayhem_proto::ENDPOINT_OPENAI_CHAT_COMPLETIONS)
+            .expect("chat contract");
+        let spec = contract
+            .request_attribute_specs
+            .get_mut("max_tokens")
+            .expect("max_tokens contract");
+        spec.minimum = Some(0.0);
+        spec.maximum = Some(262_144.0);
+        spec.multiple_of = None;
+        let state = GatewayState::from_models(vec![model.clone()]);
+        let data = DashboardData::from_state(&state);
+
+        let schema = playground_text_parameter_schema(&data, &model);
+        let controls = schema["controls"].as_array().expect("controls");
+        let output = controls
+            .iter()
+            .find(|control| control["key"] == "max_tokens")
+            .expect("output control");
+
+        assert_eq!(schema["version"], 2);
+        assert_eq!(output["minimum"], 0.0);
+        assert_eq!(output["maximum"], 262_144.0);
+        assert_eq!(output["step"], 1.0);
+        assert_eq!(output["default"], 512.0);
+        assert_eq!(output["defaultSource"], "playground");
+        assert!(controls
+            .iter()
+            .all(|control| control["key"] != "repeat_penalty"));
+        let dashboard_javascript = super::super::dashboard_ui::DASHBOARD_APP_JS;
+        assert!(!dashboard_javascript.contains("Math.min(4096"));
+        assert!(!dashboard_javascript.contains("<= 4096"));
     }
 
     #[test]

--- a/crates/mayhem-gateway/src/openai/dashboard_ui.rs
+++ b/crates/mayhem-gateway/src/openai/dashboard_ui.rs
@@ -861,7 +861,8 @@ html.js-ready .playground-interactive{min-height:clamp(520px,64vh,720px)}
 .pg-controls-toggle-copy{min-height:0;flex:1;display:flex;align-items:center;writing-mode:vertical-rl;transform:rotate(180deg);gap:.45rem}.pg-controls-toggle-copy strong{font-size:.7rem}.pg-controls-toggle-copy small{max-width:15rem;overflow:hidden;text-overflow:ellipsis;white-space:nowrap;color:var(--pg-dim);font-size:.58rem;font-weight:500}.pg-controls-chevron{transition:transform .22s var(--pg-ease)}.pg-controls.is-open .pg-controls-chevron{transform:rotate(180deg)}
 .pg-controls-body{min-width:0;flex:1;display:flex;flex-direction:column;border-left:1px solid var(--pg-line-soft)}.pg-controls-head{min-height:4.75rem;padding:.8rem 1rem;border-bottom:1px solid var(--pg-line-soft);display:flex;align-items:center;justify-content:space-between;gap:.8rem;background:rgba(255,255,255,.012)}.pg-controls-heading{min-width:0;display:flex;flex-direction:column;gap:.2rem}.pg-controls-heading>strong{overflow:hidden;text-overflow:ellipsis;white-space:nowrap;color:var(--pg-snow);font-size:.78rem;letter-spacing:-.01em}.pg-controls-heading>span{min-width:0;color:var(--pg-dim);display:flex;align-items:center;gap:.4rem;font-size:.58rem}.pg-controls-heading>span>span{min-width:0;overflow:hidden;text-overflow:ellipsis;white-space:nowrap}.pg-controls-heading i{width:.35rem;height:.35rem;flex:none;border-radius:50%;background:var(--pg-live);box-shadow:0 0 0 3px rgba(88,214,168,.08)}.pg-controls-head-actions{display:flex;gap:.4rem}.pg-controls-head button{min-height:2.45rem;padding:0 .65rem;border:1px solid var(--pg-line);border-radius:.55rem;background:rgba(13,14,17,.55);color:var(--pg-fog);display:inline-flex;align-items:center;justify-content:center;gap:.35rem;font-size:.61rem;font-weight:650}.pg-controls-head button svg{width:.9rem;height:.9rem}.pg-controls-head button:hover{border-color:rgba(229,231,235,.24);background:rgba(229,231,235,.035);color:var(--pg-snow)}.pg-controls-head [data-playground-controls-close]{display:none;width:2.45rem;padding:0}
 .pg-controls-scroll{min-height:0;flex:1;padding:1rem;overflow-y:auto;overscroll-behavior:contain;scrollbar-width:thin}.pg-context-card{padding:.78rem .82rem;border:1px solid rgba(229,231,235,.09);border-radius:.7rem;background:linear-gradient(145deg,rgba(13,14,17,.92),rgba(18,20,25,.82));display:grid;grid-template-columns:1fr auto;gap:.18rem .7rem;box-shadow:inset 0 1px 0 rgba(255,255,255,.025)}.pg-context-card span,.pg-context-card small{color:var(--pg-dim);font-size:.58rem}.pg-context-card strong{color:var(--pg-snow);font-size:.72rem;font-variant-numeric:tabular-nums}.pg-context-card small{grid-column:1/-1}
-.pg-control-group{margin-top:.95rem;display:grid;grid-template-columns:repeat(2,minmax(0,1fr));gap:.85rem .8rem}.pg-control-field{min-width:0;display:flex;flex-direction:column;gap:.38rem}.pg-control-field.span-all,.pg-control-group .span-all{grid-column:1/-1}.pg-control-field>span{color:var(--pg-fog);display:flex;align-items:baseline;justify-content:space-between;gap:.45rem;font-size:.66rem;font-weight:680}.pg-control-field em,.pg-control-field small{color:var(--pg-dim);font-size:.58rem;line-height:1.42;font-style:normal;font-weight:500}.pg-control-field input,.pg-control-field select,.pg-control-field textarea{width:100%;min-height:2.65rem;padding:.58rem .68rem;border:1px solid rgba(229,231,235,.13);border-radius:.58rem;outline:0;background:rgba(13,14,17,.82);color:var(--pg-snow);font-size:.72rem;box-shadow:inset 0 1px 0 rgba(255,255,255,.02);transition:border-color .18s ease,box-shadow .18s ease,background .18s ease}.pg-control-field textarea{resize:vertical;line-height:1.5}.pg-control-field input:hover,.pg-control-field select:hover,.pg-control-field textarea:hover{border-color:rgba(229,231,235,.2)}.pg-control-field input:focus,.pg-control-field select:focus,.pg-control-field textarea:focus{border-color:rgba(214,120,102,.62);background:rgba(17,18,22,.96);box-shadow:0 0 0 3px rgba(197,68,89,.11)}.pg-control-field input:invalid{border-color:var(--app-danger)}
+.pg-control-group{margin-top:.95rem;display:grid;grid-template-columns:repeat(2,minmax(0,1fr));gap:.85rem .8rem}.pg-control-field{min-width:0;display:flex;flex-direction:column;gap:.38rem}.pg-control-field.span-all,.pg-control-group .span-all{grid-column:1/-1}.pg-control-field>span{color:var(--pg-fog);display:flex;align-items:baseline;justify-content:space-between;gap:.45rem;font-size:.66rem;font-weight:680}.pg-control-field em,.pg-control-field small{color:var(--pg-dim);font-size:.58rem;line-height:1.42;font-style:normal;font-weight:500}.pg-control-field input,.pg-control-field select,.pg-control-field textarea{width:100%;min-height:2.65rem;padding:.58rem .68rem;border:1px solid rgba(229,231,235,.13);border-radius:.58rem;outline:0;background:rgba(13,14,17,.82);color:var(--pg-snow);font-size:.72rem;box-shadow:inset 0 1px 0 rgba(255,255,255,.02);transition:border-color .18s ease,box-shadow .18s ease,background .18s ease}.pg-control-field textarea{resize:vertical;line-height:1.5}.pg-control-field input:hover,.pg-control-field select:hover,.pg-control-field textarea:hover{border-color:rgba(229,231,235,.2)}.pg-control-field input:focus,.pg-control-field select:focus,.pg-control-field textarea:focus{border-color:rgba(214,120,102,.62);background:rgba(17,18,22,.96);box-shadow:0 0 0 3px rgba(197,68,89,.11)}.pg-control-field input:invalid,.pg-control-field select:invalid,.pg-control-field textarea:invalid{border-color:var(--app-danger)}
+.pg-settings-note{margin:.7rem 0 0;padding:.62rem .7rem;border:1px solid rgba(240,179,92,.22);border-radius:.58rem;background:rgba(240,179,92,.06);color:#e7c48d;font-size:.61rem;line-height:1.45}.pg-control-availability.is-available{color:var(--pg-live)}.pg-control-availability.is-unavailable{color:#e7a98f}.pg-control-availability.is-stale{color:#e7c48d}
 .pg-control-empty{grid-column:1/-1;margin:0!important;padding:.75rem;border:1px dashed var(--pg-line);border-radius:.55rem;color:var(--pg-dim);font-size:.62rem;line-height:1.45}
 .pg-control-slider{display:grid;grid-template-columns:minmax(0,1fr) 4.7rem;gap:.55rem;align-items:center}.pg-control-slider input[type="range"]{min-height:2rem;padding:0;border:0;background:transparent;box-shadow:none;accent-color:var(--app-accent-strong)}.pg-control-slider input[type="number"]{text-align:right;font-variant-numeric:tabular-nums}
 .pg-control-disclosure{margin-top:.9rem;border-top:1px solid var(--pg-line-soft)}.pg-control-disclosure>summary{min-height:3.5rem;padding:0 .35rem;color:var(--pg-fog);display:flex;align-items:center;justify-content:space-between;gap:.8rem;border-radius:.5rem;cursor:pointer;list-style:none;transition:background .18s ease,color .18s ease}.pg-control-disclosure>summary:hover{background:rgba(229,231,235,.025);color:var(--pg-snow)}.pg-control-disclosure>summary::-webkit-details-marker{display:none}.pg-control-disclosure>summary>span{display:flex;flex-direction:column;gap:.08rem}.pg-control-disclosure>summary strong{font-size:.68rem}.pg-control-disclosure>summary small{color:var(--pg-dim);font-size:.57rem;font-weight:500}.pg-control-disclosure>summary svg{color:var(--pg-dim);transition:transform .2s var(--pg-ease)}.pg-control-disclosure[open]>summary svg{transform:rotate(180deg)}.pg-control-disclosure-body{padding:.08rem .35rem .9rem;display:grid;grid-template-columns:repeat(2,minmax(0,1fr));gap:.8rem}.pg-control-disclosure-body>.span-all,.pg-control-group-advanced{grid-column:1/-1}.pg-control-group-advanced{margin-top:0}.pg-control-disclosure .preflight{padding:.72rem;border:1px solid var(--pg-line-soft);border-radius:.6rem;background:rgba(13,14,17,.42)}.pg-controls-reset-all{width:100%;min-height:2.65rem;margin-top:.35rem;padding:0 .8rem;justify-content:center;border:1px solid var(--pg-line);border-radius:.55rem;background:rgba(229,231,235,.018);color:var(--pg-fog)}.pg-controls-reset-all:hover{border-color:rgba(229,231,235,.22);background:rgba(229,231,235,.04);color:var(--pg-snow)}
@@ -1232,6 +1233,7 @@ pub(super) const DASHBOARD_APP_JS: &str = r##"
   const playgroundParameterProfilesKey = 'mayhem.dashboard.playgroundParameters.v1';
   const playgroundControlsOpenKey = 'mayhem.dashboard.playgroundControlsOpen';
   const localProductEventsKey = 'mayhem.dashboard.localProductEvents.v1';
+  let playgroundSettingsResetNotice = { model: '', text: '' };
 
   root.classList.toggle('amounts-hidden', storage.get(preferenceKeys.amounts) === '1');
   root.classList.toggle('motion-reduced', storage.get(preferenceKeys.motion) === '1');
@@ -1315,7 +1317,7 @@ pub(super) const DASHBOARD_APP_JS: &str = r##"
       aspectRatio: safeQuery('[data-playground-aspect-ratio][aria-pressed="true"]')?.dataset.playgroundAspectRatio || '1:1',
       voice: safeQuery('[data-playground-voice]:checked')?.value || 'af_heart',
       system: safeQuery('[data-playground-system]')?.value || '',
-      maxTokens: safeQuery('[data-playground-max-tokens]')?.value || '512',
+      maxTokens: safeQuery('[data-playground-max-tokens]')?.value || '',
       maxPrice: safeQuery('[data-playground-max-price]')?.value || '',
       maxPriceMode: selectedPlaygroundPriceMode(),
       minAttTier: safeQuery('[data-playground-min-att-tier]')?.value || ''
@@ -1343,9 +1345,9 @@ pub(super) const DASHBOARD_APP_JS: &str = r##"
         const schema = JSON.parse(option?.dataset.parameterSchema || '{}');
         return schema && typeof schema === 'object'
           ? { ...schema, controls: Array.isArray(schema.controls) ? schema.controls : [] }
-          : { version: 1, controls: [] };
+          : { version: 2, controls: [] };
       } catch (_) {
-        return { version: 1, controls: [] };
+        return { version: 2, controls: [] };
       }
     };
 
@@ -1354,14 +1356,84 @@ pub(super) const DASHBOARD_APP_JS: &str = r##"
         const parsed = JSON.parse(storage.get(playgroundParameterProfilesKey) || '{}');
         return parsed && typeof parsed === 'object' && parsed.models && typeof parsed.models === 'object'
           ? parsed
-          : { version: 1, models: {} };
+          : { version: 2, models: {} };
       } catch (_) {
-        return { version: 1, models: {} };
+        return { version: 2, models: {} };
       }
     };
 
     const playgroundParameterDefault = (control) =>
       control?.default === null || control?.default === undefined ? '' : String(control.default);
+
+    const playgroundOutputLimitControl = (schema = selectedPlaygroundParameterSchema()) =>
+      schema.controls.find((control) => control.key === 'max_tokens') || null;
+
+    const nextPlaygroundOutputLimit = (current) => {
+      const control = playgroundOutputLimitControl();
+      const value = Number(current);
+      if (!control || !Number.isFinite(value)) return null;
+      const minimum = Number.isFinite(Number(control.minimum)) ? Number(control.minimum) : 0;
+      const maximum = Number.isFinite(Number(control.maximum)) ? Number(control.maximum) : Number.MAX_SAFE_INTEGER;
+      const multipleOf = Number.isFinite(Number(control.multipleOf)) && Number(control.multipleOf) > 0
+        ? Number(control.multipleOf)
+        : 1;
+      const expanded = value > 0 ? value * 2 : Math.max(minimum, multipleOf);
+      const aligned = Math.ceil(Math.max(minimum, expanded) / multipleOf) * multipleOf;
+      return Math.min(maximum, aligned);
+    };
+
+    const playgroundParameterOption = (control, value) =>
+      Array.isArray(control?.options)
+        ? control.options.find((option) => String(option.value ?? '') === String(value ?? ''))
+        : null;
+
+    const playgroundParameterValueMatchesContract = (control, rawValue) => {
+      const raw = String(rawValue ?? '').trim();
+      if (control.kind === 'lines') {
+        const values = raw.split(/\r?\n/).map((value) => value.trim()).filter(Boolean);
+        return values.length <= 4 && values.every((value) => Array.from(value).length <= 1024);
+      }
+      if (control.kind === 'select') return Boolean(playgroundParameterOption(control, raw));
+      if (!raw) return control.key !== 'max_tokens';
+      const value = Number(raw);
+      const minimum = control.minimum === null || control.minimum === undefined ? Number.NaN : Number(control.minimum);
+      const maximum = control.maximum === null || control.maximum === undefined ? Number.NaN : Number(control.maximum);
+      const multipleOf = control.multipleOf === null || control.multipleOf === undefined ? Number.NaN : Number(control.multipleOf);
+      if (!Number.isFinite(value) || (control.kind === 'integer' && !Number.isInteger(value))) return false;
+      if (Number.isFinite(minimum) && value < minimum) return false;
+      if (Number.isFinite(maximum) && value > maximum) return false;
+      if (Number.isFinite(multipleOf) && multipleOf > 0) {
+        const quotient = value / multipleOf;
+        if (Math.abs(quotient - Math.round(quotient)) > Number.EPSILON * Math.max(1, Math.abs(quotient)) * 16) return false;
+      }
+      return true;
+    };
+
+    const playgroundAvailabilityIsFresh = () =>
+      safeQuery('[data-page-status-freshness]')?.dataset.freshnessExpired !== 'true';
+
+    const updatePlaygroundParameterAvailability = (control, input, option) => {
+      const status = safeQuery('[data-playground-parameter-status]', input.closest('.pg-control-field'));
+      if (!status) return;
+      status.hidden = true;
+      status.classList.remove('is-available', 'is-unavailable', 'is-stale');
+      if (!control.speciality || !option || typeof option.available !== 'boolean') return;
+      const liveProviders = Number(option.liveProviderCount || 0);
+      const canonicalProviders = Number(option.canonicalProviderCount || 0);
+      status.hidden = false;
+      if (!playgroundAvailabilityIsFresh()) {
+        status.classList.add('is-stale');
+        status.textContent = 'Provider availability expired in this tab. Refresh to reconfirm.';
+      } else if (option.available) {
+        status.classList.add('is-available');
+        status.textContent = `Available now from ${liveProviders.toLocaleString()} live ${liveProviders === 1 ? 'provider' : 'providers'}.`;
+      } else {
+        status.classList.add('is-unavailable');
+        status.textContent = canonicalProviders
+          ? 'Supported by the model, but unavailable from live providers right now. The gateway will recheck when you send.'
+          : 'No catalog provider currently advertises this mode. The gateway will recheck when you send.';
+      }
+    };
 
     const playgroundParameterValues = (validate = false) => {
       const schema = selectedPlaygroundParameterSchema();
@@ -1375,11 +1447,12 @@ pub(super) const DASHBOARD_APP_JS: &str = r##"
         if (control.kind === 'lines') {
           const values = raw.split(/\r?\n/).map((value) => value.trim()).filter(Boolean);
           if (values.length > 4) input.setCustomValidity('Enter no more than four stop sequences.');
-          else if (values.some((value) => value.length > 256)) input.setCustomValidity('Keep each stop sequence at 256 characters or fewer.');
+          else if (values.some((value) => Array.from(value).length > 1024)) input.setCustomValidity('Keep each stop sequence at 1,024 characters or fewer.');
           else if (values.length) parameters[control.key] = values;
         } else if (control.kind === 'select') {
-          const allowed = Array.isArray(control.options) ? control.options.map((option) => String(option.value)) : [];
-          if (raw && !allowed.includes(raw)) input.setCustomValidity('Choose a supported value.');
+          const option = playgroundParameterOption(control, raw);
+          updatePlaygroundParameterAvailability(control, input, option);
+          if (!option) input.setCustomValidity('Choose a supported value.');
           else if (raw) parameters[control.key] = raw;
         } else {
           if (!raw && control.key === 'max_tokens') input.setCustomValidity('Choose an output limit.');
@@ -1391,6 +1464,12 @@ pub(super) const DASHBOARD_APP_JS: &str = r##"
             else if (control.kind === 'integer' && !Number.isInteger(value)) input.setCustomValidity('Enter a whole number.');
             else if (Number.isFinite(minimum) && value < minimum) input.setCustomValidity(`Choose ${minimum} or higher.`);
             else if (Number.isFinite(maximum) && value > maximum) input.setCustomValidity(`Choose ${maximum} or lower.`);
+            else if (Number.isFinite(Number(control.multipleOf)) && Number(control.multipleOf) > 0) {
+              const quotient = value / Number(control.multipleOf);
+              if (Math.abs(quotient - Math.round(quotient)) > Number.EPSILON * Math.max(1, Math.abs(quotient)) * 16) {
+                input.setCustomValidity(`Choose a multiple of ${control.multipleOf}.`);
+              } else parameters[control.key] = value;
+            }
             else parameters[control.key] = value;
           }
         }
@@ -1407,15 +1486,16 @@ pub(super) const DASHBOARD_APP_JS: &str = r##"
     };
 
     const updatePlaygroundParameterState = () => {
-      const { parameters, schema } = playgroundParameterValues(false);
+      const { valid, parameters, schema } = playgroundParameterValues(false);
       const changed = schema.controls.reduce((count, control) => {
         const current = parameters[control.key];
         const expected = control.default;
         if (current === undefined && (expected === undefined || expected === null)) return count;
+        if (current === undefined && control.defaultSource === 'model') return count;
         return String(current ?? '') === String(expected ?? '') ? count : count + 1;
       }, 0);
       const state = safeQuery('[data-playground-controls-state]');
-      if (state) state.textContent = changed ? `${changed} customized` : 'Model defaults';
+      if (state) state.textContent = valid ? (changed ? `${changed} customized` : 'Defaults') : 'Review settings';
     };
 
     const savePlaygroundParameterProfile = () => {
@@ -1426,7 +1506,12 @@ pub(super) const DASHBOARD_APP_JS: &str = r##"
         values[input.dataset.playgroundParameter] = input.value;
       });
       const profiles = readPlaygroundParameterProfiles();
-      profiles.models[model] = { values, updatedAt: Date.now() };
+      profiles.version = 2;
+      profiles.models[model] = {
+        schemaVersion: selectedPlaygroundParameterSchema().version || 2,
+        values,
+        updatedAt: Date.now()
+      };
       storage.set(playgroundParameterProfilesKey, JSON.stringify(profiles));
       updatePlaygroundParameterState();
     };
@@ -1440,6 +1525,21 @@ pub(super) const DASHBOARD_APP_JS: &str = r##"
       }
     };
 
+    const playgroundParameterDefaultSummary = (control) => {
+      let value = control.default;
+      if (control.modelDefault) {
+        value = playgroundParameterOption(control, control.modelDefault)?.label || control.modelDefault;
+      }
+      if (value === null || value === undefined || value === '') return '';
+      const numeric = Number(value);
+      const display = typeof value === 'number' && Number.isFinite(numeric)
+        ? numeric.toLocaleString()
+        : String(value);
+      return control.defaultSource === 'playground'
+        ? `Playground default: ${display}`
+        : `Model default: ${display}`;
+    };
+
     const makePlaygroundParameterField = (control, value) => {
       const field = document.createElement('label');
       field.className = `pg-control-field${control.kind === 'lines' ? ' span-all' : ''}`;
@@ -1447,6 +1547,12 @@ pub(super) const DASHBOARD_APP_JS: &str = r##"
       field.htmlFor = id;
       const title = document.createElement('span');
       title.textContent = control.label || control.key;
+      const defaultSummary = playgroundParameterDefaultSummary(control);
+      if (defaultSummary) {
+        const source = document.createElement('em');
+        source.textContent = defaultSummary;
+        title.append(source);
+      }
       field.append(title);
       let input;
       if (control.kind === 'select') {
@@ -1500,9 +1606,20 @@ pub(super) const DASHBOARD_APP_JS: &str = r##"
       }
       if (control.help) {
         const help = document.createElement('small');
+        help.id = `${id}-help`;
         help.textContent = control.help;
         field.append(help);
+        input.setAttribute('aria-describedby', help.id);
       }
+      const status = document.createElement('small');
+      status.id = `${id}-status`;
+      status.dataset.playgroundParameterStatus = '';
+      status.className = 'pg-control-availability';
+      status.hidden = true;
+      field.append(status);
+      const describedBy = input.getAttribute('aria-describedby');
+      input.setAttribute('aria-describedby', [describedBy, status.id].filter(Boolean).join(' '));
+      updatePlaygroundParameterAvailability(control, input, playgroundParameterOption(control, input.value));
       return field;
     };
 
@@ -1517,10 +1634,14 @@ pub(super) const DASHBOARD_APP_JS: &str = r##"
       if (!primary || !advanced) return;
       primary.replaceChildren();
       advanced.replaceChildren();
+      const controlKeys = new Set(schema.controls.map((control) => control.key));
+      let discarded = Object.keys(profile).filter((key) => !controlKeys.has(key)).length;
       for (const control of schema.controls) {
-        const value = Object.prototype.hasOwnProperty.call(profile, control.key)
-          ? String(profile[control.key])
-          : playgroundParameterDefault(control);
+        const hasSavedValue = Object.prototype.hasOwnProperty.call(profile, control.key);
+        const savedValue = hasSavedValue ? String(profile[control.key]) : '';
+        const savedValueIsValid = hasSavedValue && playgroundParameterValueMatchesContract(control, savedValue);
+        if (hasSavedValue && !savedValueIsValid) discarded += 1;
+        const value = savedValueIsValid ? savedValue : playgroundParameterDefault(control);
         const field = makePlaygroundParameterField(control, value);
         (control.section === 'advanced' ? advanced : primary).append(field);
       }
@@ -1536,6 +1657,28 @@ pub(super) const DASHBOARD_APP_JS: &str = r##"
       if (modelName) modelName.textContent = selected?.dataset.modelName || model.value;
       const context = safeQuery('[data-playground-context-value]');
       if (context) context.textContent = schema.contextLabel ? `${schema.contextLabel} tokens` : 'Not published';
+      const outputMaximum = safeQuery('[data-playground-output-maximum]');
+      const outputControl = playgroundOutputLimitControl(schema);
+      if (outputMaximum) {
+        const maximum = Number(outputControl?.maximum);
+        outputMaximum.textContent = Number.isFinite(maximum)
+          ? `${maximum.toLocaleString()} tokens`
+          : 'Not published';
+      }
+      const settingsNote = safeQuery('[data-playground-settings-note]');
+      if (settingsNote) {
+        if (discarded) {
+          playgroundSettingsResetNotice = {
+            model: model.value,
+            text: `${discarded} saved ${discarded === 1 ? 'setting no longer matches' : 'settings no longer match'} this model and ${discarded === 1 ? 'was' : 'were'} reset.`
+          };
+        } else if (playgroundSettingsResetNotice.model !== model.value) {
+          playgroundSettingsResetNotice = { model: '', text: '' };
+        }
+        settingsNote.hidden = !playgroundSettingsResetNotice.text;
+        settingsNote.textContent = playgroundSettingsResetNotice.text;
+      }
+      if (discarded) savePlaygroundParameterProfile();
       updatePlaygroundParameterState();
     };
 
@@ -2339,8 +2482,11 @@ pub(super) const DASHBOARD_APP_JS: &str = r##"
         return null;
       }
       tier?.setCustomValidity('');
+      const outputControl = generation.schema.controls.find((control) => control.key === 'max_tokens');
+      const defaultOutputTokens = Number(outputControl?.default);
       return {
-        outputTokens: generation.parameters.max_tokens || 512,
+        outputTokens: generation.parameters.max_tokens
+          ?? (Number.isFinite(defaultOutputTokens) ? defaultOutputTokens : 0),
         generationParameters: generation.parameters,
         maxPriceAu,
         minAttTier,
@@ -2920,16 +3066,18 @@ pub(super) const DASHBOARD_APP_JS: &str = r##"
         copy.append(copyLabel);
         resultActions.append(copy);
         if (outputLimitReached) {
-          const continuation = document.createElement('button');
-          const nextOutputLimit = Math.min(4096, Math.max(64, requestedMaxTokens * 2));
-          continuation.className = 'pg-text-action';
-          continuation.type = 'button';
-          continuation.dataset.playgroundContinue = '';
-          continuation.dataset.nextMaxTokens = String(nextOutputLimit);
-          continuation.textContent = nextOutputLimit > requestedMaxTokens
-            ? `Continue with ${nextOutputLimit.toLocaleString()}-token limit`
-            : 'Continue response';
-          resultActions.append(continuation);
+          const nextOutputLimit = nextPlaygroundOutputLimit(requestedMaxTokens);
+          if (nextOutputLimit !== null) {
+            const continuation = document.createElement('button');
+            continuation.className = 'pg-text-action';
+            continuation.type = 'button';
+            continuation.dataset.playgroundContinue = '';
+            continuation.dataset.nextMaxTokens = String(nextOutputLimit);
+            continuation.textContent = nextOutputLimit > requestedMaxTokens
+              ? `Continue with ${nextOutputLimit.toLocaleString()}-token limit`
+              : 'Continue response';
+            resultActions.append(continuation);
+          }
         }
         if (reportedSessionId) {
           const receipt = document.createElement('a');
@@ -3217,7 +3365,7 @@ pub(super) const DASHBOARD_APP_JS: &str = r##"
         resetPlaygroundParameterProfile();
         syncPlaygroundParameterRail();
         savePlaygroundDraft();
-        announce('Generation settings reset to this model\'s defaults.', false, false);
+        announce('Generation settings reset to their defaults.', false, false);
         return;
       }
       if (!event.target.closest('[data-playground-model-picker]')) closePlaygroundModelPicker(false);
@@ -3521,7 +3669,6 @@ pub(super) const DASHBOARD_APP_JS: &str = r##"
         const imagePrompt = safeQuery('[data-playground-image-prompt]');
         const speechText = safeQuery('[data-playground-speech-text]');
         const system = safeQuery('[data-playground-system]');
-        const output = safeQuery('[data-playground-max-tokens]');
         const price = safeQuery('[data-playground-max-price]');
         const tier = safeQuery('[data-playground-min-att-tier]');
         if (model) {
@@ -3534,7 +3681,6 @@ pub(super) const DASHBOARD_APP_JS: &str = r##"
         if (imagePrompt) imagePrompt.value = '';
         if (speechText) speechText.value = '';
         if (system) system.value = '';
-        if (output) output.value = '512';
         if (price) price.value = '';
         if (tier) tier.value = '';
         document.querySelectorAll('[data-playground-aspect-ratio]').forEach((button) => {
@@ -3567,10 +3713,16 @@ pub(super) const DASHBOARD_APP_JS: &str = r##"
         const prompt = safeQuery('[data-playground-prompt]');
         const output = safeQuery('[data-playground-max-tokens]');
         const nextOutput = Number.parseInt(continuation.dataset.nextMaxTokens || '', 10);
-        if (output && Number.isInteger(nextOutput) && nextOutput >= 64 && nextOutput <= 4096) {
+        const outputControl = playgroundOutputLimitControl();
+        if (output && Number.isInteger(nextOutput) && outputControl
+          && playgroundParameterValueMatchesContract(outputControl, String(nextOutput))) {
           output.value = String(nextOutput);
           setPlaygroundControlsOpen(true);
           savePlaygroundParameterProfile();
+        } else {
+          announce('The selected model does not support that continuation limit. Review its output setting.', true);
+          setPlaygroundControlsOpen(true);
+          return;
         }
         if (prompt) {
           prompt.value = 'Continue from where you stopped.';
@@ -3905,7 +4057,8 @@ pub(super) const DASHBOARD_APP_JS: &str = r##"
 
       const pageMarker = safeQuery('[data-page-status-freshness][data-expires-at-ms]');
       const pageExpiresAt = Number.parseInt(pageMarker?.dataset.expiresAtMs || '', 10);
-      if (pageMarker && Number.isFinite(pageExpiresAt) && now > pageExpiresAt) {
+      if (pageMarker && pageMarker.dataset.freshnessExpired !== 'true'
+        && Number.isFinite(pageExpiresAt) && now > pageExpiresAt) {
         pageMarker.dataset.freshnessExpired = 'true';
         const statusText = safeQuery('[data-page-status-text]');
         const indicator = safeQuery('.topbar-status .state-indicator');
@@ -3927,6 +4080,7 @@ pub(super) const DASHBOARD_APP_JS: &str = r##"
           playgroundAvailability.textContent = 'Refresh to reconfirm';
           playgroundAvailability.dataset.volatileExpired = 'true';
         }
+        updatePlaygroundParameterState();
       }
     };
 
@@ -3982,9 +4136,12 @@ pub(super) const DASHBOARD_APP_JS: &str = r##"
         }
       }
       if (playgroundSystem && typeof savedDraft.system === 'string') playgroundSystem.value = savedDraft.system;
-      if (playgroundMaxTokens && /^\d+$/.test(String(savedDraft.maxTokens || ''))) {
+      if (playgroundMaxTokens && /^\d+$/.test(String(savedDraft.maxTokens ?? ''))) {
         const savedOutput = Number.parseInt(String(savedDraft.maxTokens), 10);
-        if (savedOutput >= 64 && savedOutput <= 4096) playgroundMaxTokens.value = String(savedOutput);
+        const outputControl = playgroundOutputLimitControl();
+        if (outputControl && playgroundParameterValueMatchesContract(outputControl, String(savedOutput))) {
+          playgroundMaxTokens.value = String(savedOutput);
+        }
       }
       const restoredPriceMode = selectedPlaygroundPriceMode();
       const savedPriceMode = savedDraft.maxPriceMode === 'fixed' ? 'fixed' : 'rate';

--- a/crates/mayhem-gateway/tests/dashboard-browser-smoke.mjs
+++ b/crates/mayhem-gateway/tests/dashboard-browser-smoke.mjs
@@ -472,8 +472,25 @@ try {
   check(await fixedOption.count() > 0, 'Playground price controls', 'offers a fixed-only fixture model');
   await choosePlaygroundModel(await rateOption.getAttribute('value'));
   const rateSchema = JSON.parse((await playgroundModel.locator('option:checked').getAttribute('data-parameter-schema')) || '{}');
+  const rateOutputControl = rateSchema.controls.find((control) => control.key === 'max_tokens');
+  check(Number(rateOutputControl?.maximum) > 4096, 'Playground output limit', 'publishes the selected model\'s full signed output boundary above the former UI cap');
+  const localizedOutputMaximum = await page.evaluate((value) => Number(value).toLocaleString(), rateOutputControl.maximum);
+  equal(
+    await page.locator('[data-playground-output-maximum]').innerText(),
+    `${localizedOutputMaximum} tokens`,
+    'Playground output limit',
+    'shows the exact model-derived maximum beside the shared context limit',
+  );
   const renderedParameters = await page.locator('[data-playground-parameter]').evaluateAll((inputs) => inputs.map((input) => input.dataset.playgroundParameter));
   equal(JSON.stringify(renderedParameters.sort()), JSON.stringify(rateSchema.controls.map((control) => control.key).sort()), 'Playground generation settings', 'renders exactly the settings published by the selected model contract');
+  const primaryParameters = rateSchema.controls.filter((control) => control.section === 'primary').map((control) => control.key);
+  check(primaryParameters.length <= 3 && primaryParameters.every((key) => ['max_tokens', 'thinking_mode', 'temperature'].includes(key)), 'Playground generation settings', 'keeps the visible settings focused on output, thinking, and temperature');
+  check(!renderedParameters.includes('repeat_penalty'), 'Playground generation settings', 'does not expose the server-controlled repeat penalty as an editable setting');
+  const thinkingControl = rateSchema.controls.find((control) => control.key === 'thinking_mode');
+  if (thinkingControl) {
+    equal(String(thinkingControl.options[0]?.value ?? ''), '', 'Playground thinking control', 'offers the signed model default without forcing a provider-local default');
+    check(String(thinkingControl.options[0]?.label || '').startsWith('Model default'), 'Playground thinking control', 'names the effective model-default choice clearly');
+  }
   const rateTemperature = page.locator('[data-playground-parameter="temperature"]');
   const rateTopP = page.locator('[data-playground-parameter="top_p"]');
   await rateTemperature.fill('0.4');
@@ -499,6 +516,16 @@ try {
   await page.reload({ waitUntil: 'domcontentloaded' });
   equal(await playgroundModel.inputValue(), rateModelValue, 'Playground generation settings', 'restores the selected model after refresh');
   equal(await rateTemperature.inputValue(), '0.4', 'Playground generation settings', 'restores the model profile after refresh');
+  await page.evaluate(({ model, invalidOutput }) => {
+    const key = 'mayhem.dashboard.playgroundParameters.v1';
+    const profiles = JSON.parse(localStorage.getItem(key) || '{"version":2,"models":{}}');
+    profiles.models[model].values.max_tokens = invalidOutput;
+    localStorage.setItem(key, JSON.stringify(profiles));
+  }, { model: rateModelValue, invalidOutput: String(Number(rateOutputControl.maximum) + 1) });
+  await page.reload({ waitUntil: 'domcontentloaded' });
+  equal(await playgroundModel.inputValue(), rateModelValue, 'Playground generation settings', 'keeps the selected model while revalidating its saved profile');
+  equal(await playgroundOutput.inputValue(), String(rateOutputControl.default), 'Playground generation settings', 'resets only a saved value that no longer matches the model contract');
+  check(await page.locator('[data-playground-settings-note]').isVisible(), 'Playground generation settings', 'explains when an incompatible saved setting was reset');
   equal(await playgroundControlsToggle.getAttribute('aria-expanded'), 'true', 'Playground generation settings', 'restores the desktop rail state');
   await page.setViewportSize({ width: 390, height: 844 });
   await page.waitForTimeout(240);
@@ -525,12 +552,25 @@ try {
   }), 'Playground generation settings', 'gives routing evidence the full disclosure width');
   equal(await page.locator('[data-playground-price-unit]').innerText(), '$ / 1M-unit basket', 'Playground price controls', 'names the composite rate basis');
   await playgroundPrice.fill('0.50');
+  const largeOutputLimit = Math.min(100000, Number(rateOutputControl.maximum));
+  await playgroundOutput.fill(String(largeOutputLimit));
+  let selectedThinkingMode = '';
+  if (thinkingControl) {
+    selectedThinkingMode = String(thinkingControl.options.find((option) => option.value === 'enabled')?.value
+      || thinkingControl.options.find((option) => option.value)?.value
+      || '');
+    if (selectedThinkingMode) {
+      await page.locator('[data-playground-parameter="thinking_mode"]').selectOption(selectedThinkingMode);
+    }
+  }
   await playgroundPrompt.fill('Verify the rate-price request control.');
   const rateRequestPromise = page.waitForRequest((request) => request.url().endsWith('/v1/chat/completions') && request.method() === 'POST');
   await playgroundSend.click();
   const rateRequest = await rateRequestPromise;
   const rateRequestBody = rateRequest.postDataJSON();
   equal(rateRequestBody.temperature, 0.4, 'Playground generation settings', 'sends the selected temperature to the chat endpoint');
+  equal(rateRequestBody.max_tokens, largeOutputLimit, 'Playground output limit', 'submits a contract-valid output limit above the former UI cap without clamping it');
+  if (selectedThinkingMode) equal(rateRequestBody.thinking_mode, selectedThinkingMode, 'Playground thinking control', 'sends the user\'s exact thinking choice without silently changing it');
   if (await rateTopP.count()) equal(rateRequestBody.top_p, 0.8, 'Playground generation settings', 'sends advanced sampling settings to the chat endpoint');
   equal(rateRequest.headers()['x-mayhem-max-price-au'], '500000000000000', 'Playground price controls', 'converts $0.50 per 1M-unit basket to the gateway rate basis');
   // Wait on the result COUNT: a `.last()` wait would match the previous
@@ -575,7 +615,9 @@ try {
   await page.locator('[data-playground-reset-draft]').click();
   equal(await playgroundPrompt.inputValue(), '', 'Playground draft reset', 'clears the tab-scoped message draft');
   equal(await page.locator('[data-playground-system]').inputValue(), '', 'Playground draft reset', 'clears saved system instructions');
-  equal(await playgroundOutput.inputValue(), '512', 'Playground draft reset', 'restores the output limit default');
+  const resetSchema = JSON.parse((await playgroundModel.locator('option:checked').getAttribute('data-parameter-schema')) || '{}');
+  const resetOutputDefault = resetSchema.controls.find((control) => control.key === 'max_tokens')?.default;
+  equal(await playgroundOutput.inputValue(), String(resetOutputDefault), 'Playground draft reset', 'restores the selected model\'s published Playground default');
   equal(await playgroundPrice.inputValue(), '', 'Playground draft reset', 'clears the saved price ceiling');
   equal(await page.evaluate(() => sessionStorage.getItem('mayhem.dashboard.playgroundDraft')), null, 'Playground draft reset', 'removes the tab-scoped saved record');
   equal(await page.evaluate(() => localStorage.getItem('mayhem.dashboard.playgroundParameters.v1')), null, 'Playground draft reset', 'removes saved per-model generation profiles');


### PR DESCRIPTION
## Summary

- derive the Playground output limit from the selected model's signed contract and expose the full supported range instead of clamping it to 4,096
- keep the primary UI focused on output limit, thinking, and temperature, with clear model/Playground defaults and live availability guidance
- preserve exact user choices, revalidate saved per-model settings when contracts change, and explain any individual resets
- remove the unsupported repeat-penalty control and align stop-sequence validation with the existing gateway limit

This is intentionally UI-only: it does not change routing, provider execution, request admission, or gateway contract enforcement.

## Verification

- `cargo test -p mayhem-gateway --lib` ? 272 passed
- `node crates/mayhem-gateway/tests/dashboard-browser-smoke.mjs --base-url <isolated-workbench>` ? 1,634 assertions across 20 routes and 6 viewport classes
- `node scripts/dashboard-workbench-smoke.mjs --no-build --timeout-ms 30000` ? 10,905 assertions across 162 route/scenario combinations
- manual in-app browser pass at the 262,144-token boundary, including a valid 100,000-token selection and console-error check
- `cargo fmt --all`
- `git diff --check`

## CI baseline note

The PR-specific dashboard workbench and source-boundary jobs pass. The Rust matrix currently stops on the unchanged `crates/mayhem-cli/src/intercom_runtime.rs:51` `clippy::suspicious_open_options` finding. The current `main` run fails on the same line and lint: https://github.com/Trac-Systems/openmayhem/actions/runs/30031862131

That unrelated CLI/backend file is intentionally not changed here so this PR remains UI-only.

### Live route validation

- live paid Playground request through `hauhaucs/qwen3.6-35b-a3b-uncensored`
- requested an 8,192-token ceiling with thinking explicitly disabled
- final signed receipt recorded 7,705 output tokens and 39 input tokens, proving output beyond the former 4,096 cap
- provider returned `length` / output-limit completion after 328.1 seconds; the UI preserved the response and offered continuation at 16,384 tokens
- browser console remained clean; final charge was $0.0026987
