### PR TITLE
Recover failed isolated vLLM workers while healthy requests continue

### DIFF
--- a/crates/mayhem-cli/src/main.rs
+++ b/crates/mayhem-cli/src/main.rs
@@ -61315,6 +61315,9 @@ trait ProviderSessionResponder {
     fn component_healthy(&mut self) -> bool {
         true
     }
+    fn recover_component(&mut self) -> Result<bool> {
+        Ok(false)
+    }
     fn supports_live_text_streaming(&self) -> bool {
         false
     }
@@ -61409,6 +61412,10 @@ impl ProviderSessionResponder for EngineProviderSessionResponder {
 
     fn component_healthy(&mut self) -> bool {
         self.backend.component_healthy()
+    }
+
+    fn recover_component(&mut self) -> Result<bool> {
+        self.backend.recover_component().map_err(Into::into)
     }
 
     fn process_ids(&self) -> Vec<u32> {
@@ -78974,6 +78981,24 @@ async fn serve_provider_sessions(
                 engine_recovery.mark_failed(
                     "provider engine child exited while idle; no user session caused the failure",
                 );
+            }
+            if engine_recovery.retry_due(Instant::now()) {
+                match responder.recover_component() {
+                    Ok(true) => {
+                        engine_recovery.mark_recovered();
+                        engine_watchdog.reset_after_restart();
+                        engine_watchdog_reject = None;
+                        provider_log(
+                            ctx.args,
+                            "Failed provider worker recovered; healthy concurrent requests were preserved.",
+                        );
+                    }
+                    Ok(false) => {}
+                    Err(err) => engine_recovery.mark_reload_failed(
+                        format!("isolated provider worker recovery failed: {err:#}"),
+                        Instant::now(),
+                    ),
+                }
             }
             if engine_recovery.retry_due(Instant::now()) && sessions.is_empty() {
                 heartbeat_load.set_accepting_new(false);

--- a/crates/mayhem-cli/src/main.rs
+++ b/crates/mayhem-cli/src/main.rs
@@ -68,10 +68,10 @@ use mayhem_enclave::{
 use mayhem_engine::ComfyUiBackend;
 use mayhem_engine::{
     ArtifactChunk, AudioTranscriptionRequest as EngineAudioTranscriptionRequest, CancellationToken,
-    ComfyUiCustomNodePackage, ComfyUiModelFile, ConcurrentGenerationBackend, EngineBackend,
-    EngineError, GenerateRequest, GenerateSpecialityParameter, GenerateSpecialityTarget,
-    GrammarSpec, ImageGenerationRequest as EngineImageGenerationRequest, LoadConfig,
-    MediaGenerationRequest as EngineMediaGenerationRequest, MediaInput, ModelArtifact,
+    ComfyUiCustomNodePackage, ComfyUiModelFile, ComponentRecovery, ConcurrentGenerationBackend,
+    EngineBackend, EngineError, GenerateRequest, GenerateSpecialityParameter,
+    GenerateSpecialityTarget, GrammarSpec, ImageGenerationRequest as EngineImageGenerationRequest,
+    LoadConfig, MediaGenerationRequest as EngineMediaGenerationRequest, MediaInput, ModelArtifact,
     SpeechReferenceAudio, SpeechRequest, TokenChunk, ToolSpec, WorkflowGenerationRequest,
     WorkflowInputFile, MTMD_MEDIA_MARKER,
 };
@@ -61315,8 +61315,8 @@ trait ProviderSessionResponder {
     fn component_healthy(&mut self) -> bool {
         true
     }
-    fn recover_component(&mut self) -> Result<bool> {
-        Ok(false)
+    fn recover_component(&mut self) -> Result<ComponentRecovery> {
+        Ok(ComponentRecovery::Unsupported)
     }
     fn supports_live_text_streaming(&self) -> bool {
         false
@@ -61414,7 +61414,7 @@ impl ProviderSessionResponder for EngineProviderSessionResponder {
         self.backend.component_healthy()
     }
 
-    fn recover_component(&mut self) -> Result<bool> {
+    fn recover_component(&mut self) -> Result<ComponentRecovery> {
         self.backend.recover_component().map_err(Into::into)
     }
 
@@ -78982,9 +78982,10 @@ async fn serve_provider_sessions(
                     "provider engine child exited while idle; no user session caused the failure",
                 );
             }
+            let mut component_recovery_pending = false;
             if engine_recovery.retry_due(Instant::now()) {
                 match responder.recover_component() {
-                    Ok(true) => {
+                    Ok(ComponentRecovery::Recovered) => {
                         engine_recovery.mark_recovered();
                         engine_watchdog.reset_after_restart();
                         engine_watchdog_reject = None;
@@ -78993,14 +78994,15 @@ async fn serve_provider_sessions(
                             "Failed provider worker recovered; healthy concurrent requests were preserved.",
                         );
                     }
-                    Ok(false) => {}
+                    Ok(ComponentRecovery::Pending) => component_recovery_pending = true,
+                    Ok(ComponentRecovery::Unsupported) => {}
                     Err(err) => engine_recovery.mark_reload_failed(
                         format!("isolated provider worker recovery failed: {err:#}"),
                         Instant::now(),
                     ),
                 }
             }
-            if engine_recovery.retry_due(Instant::now()) && sessions.is_empty() {
+            if !component_recovery_pending && engine_recovery.retry_due(Instant::now()) && sessions.is_empty() {
                 heartbeat_load.set_accepting_new(false);
                 let reason = engine_recovery
                     .reason()

--- a/crates/mayhem-engine/src/lib.rs
+++ b/crates/mayhem-engine/src/lib.rs
@@ -1523,6 +1523,11 @@ pub trait EngineBackend {
     fn component_healthy(&mut self) -> bool {
         true
     }
+    /// Repair failed components without interrupting healthy concurrent calls.
+    /// False means that a full reload is still required after requests drain.
+    fn recover_component(&mut self) -> Result<bool> {
+        Ok(false)
+    }
     fn process_ids(&self) -> Vec<u32> {
         Vec::new()
     }
@@ -8298,7 +8303,9 @@ mod vllm_backend {
                 n_vocab: info.n_vocab,
             };
             self.concurrent_generation = Some(Arc::new(VllmConcurrentGeneration {
-                dispatch: VllmGenerationDispatch::Isolated(self.isolated_workers.clone()),
+                dispatch: VllmGenerationDispatch::Isolated(Arc::new(RwLock::new(
+                    self.isolated_workers.clone(),
+                ))),
                 next_id: Arc::clone(&self.next_id),
                 generation_gate: Arc::clone(&self.generation_gate),
                 generation_epoch: Arc::clone(&self.generation_epoch),
@@ -8326,7 +8333,7 @@ mod vllm_backend {
 
     enum VllmGenerationDispatch {
         Shared(Arc<VllmWorker>),
-        Isolated(Vec<Arc<VllmWorker>>),
+        Isolated(Arc<RwLock<Vec<Arc<VllmWorker>>>>),
     }
 
     struct VllmConcurrentGeneration {
@@ -8379,15 +8386,19 @@ mod vllm_backend {
 
             let permit = self.limiter.acquire(cancellation)?;
             let (worker, _isolated_guard) = match &self.dispatch {
-                VllmGenerationDispatch::Shared(worker) => (worker.as_ref(), None),
+                VllmGenerationDispatch::Shared(worker) => (Arc::clone(worker), None),
                 VllmGenerationDispatch::Isolated(workers) => {
+                    let workers = workers.read().unwrap_or_else(|p| p.into_inner());
                     if !workers.iter().all(|worker| worker.component_healthy()) {
                         return Err(EngineError::Vllm(
                             "isolated vLLM worker pool is unhealthy; reload required".to_owned(),
                         ));
                     }
-                    let worker = workers[permit.slot].as_ref();
-                    (worker, Some(IsolatedGenerationGuard { worker }))
+                    let worker = Arc::clone(&workers[permit.slot]);
+                    let guard = IsolatedGenerationGuard {
+                        worker: Arc::clone(&worker),
+                    };
+                    (worker, Some(guard))
                 }
             };
             let route_capacity = usize::try_from(request.max_new_tokens)
@@ -8405,11 +8416,11 @@ mod vllm_backend {
         }
     }
 
-    struct IsolatedGenerationGuard<'a> {
-        worker: &'a VllmWorker,
+    struct IsolatedGenerationGuard {
+        worker: Arc<VllmWorker>,
     }
 
-    impl Drop for IsolatedGenerationGuard<'_> {
+    impl Drop for IsolatedGenerationGuard {
         fn drop(&mut self) {
             // An interrupted protocol exchange must not overlap the next lease.
             if !self.worker.router.is_idle() {
@@ -8435,6 +8446,17 @@ mod vllm_backend {
 
         fn capacity(&self) -> usize {
             self.capacity
+        }
+
+        fn try_acquire_slot(self: &Arc<Self>, slot: usize) -> Option<GenerationPermit> {
+            let mut active = self.active.lock().unwrap_or_else(|p| p.into_inner());
+            if slot >= self.capacity || !active.insert(slot) {
+                return None;
+            }
+            Some(GenerationPermit {
+                limiter: Arc::clone(self),
+                slot,
+            })
         }
 
         fn acquire(self: &Arc<Self>, cancellation: &CancellationToken) -> Result<GenerationPermit> {
@@ -8671,6 +8693,105 @@ mod vllm_backend {
                         .as_ref()
                         .is_some_and(|worker| worker.component_healthy())
                 }
+        }
+
+        fn recover_component(&mut self) -> Result<bool> {
+            if self.loaded_topology != Some(VllmGenerationTopology::IsolatedWorkers) {
+                return Ok(false);
+            }
+            let Some(concurrent) = self.concurrent_generation.clone() else {
+                return Ok(false);
+            };
+            let VllmGenerationDispatch::Isolated(dispatch) = &concurrent.dispatch else {
+                return Ok(false);
+            };
+            let loaded = self.loaded.as_ref().ok_or(EngineError::NotLoaded)?;
+            for index in 0..self.isolated_workers.len() {
+                let old = &self.isolated_workers[index];
+                if old.component_healthy() {
+                    continue;
+                }
+                // A failing call must finish releasing its route and slot first.
+                // Healthy slots remain leased and keep their original worker.
+                let Some(_permit) = concurrent.limiter.try_acquire_slot(index) else {
+                    return Ok(false);
+                };
+                let evidence = &self.loaded_per_worker[index];
+                let payload = evidence["load_payload"].clone();
+                let limit = evidence["memory_limit_bytes"].as_u64();
+                let address_limit = evidence["vllm_worker_address_space_limit_bytes"]
+                    .as_u64()
+                    .ok_or_else(|| {
+                        EngineError::Vllm(
+                            "isolated recovery is missing the original containment limit"
+                                .to_owned(),
+                        )
+                    })?;
+                let execution_probe = payload
+                    .get("vllm_compilation_mode")
+                    .is_some_and(|v| !v.is_null())
+                    || payload
+                        .get("vllm_cudagraph_mode")
+                        .is_some_and(|v| !v.is_null());
+                old.terminate();
+                let worker = Arc::new(VllmWorker::spawn_isolated(
+                    &self.python,
+                    limit,
+                    address_limit,
+                    self.cache_root.as_deref(),
+                    execution_probe,
+                )?);
+                let info = worker.call_streaming::<WorkerLoadInfo>(
+                    self.next_request_id(),
+                    "load",
+                    payload,
+                    &mut |_| Ok(()),
+                    None,
+                    true,
+                    2,
+                )?;
+                let tokens = info.kv_cache_size_tokens.unwrap_or(0);
+                let expected_execution: Option<WorkerExecutionInfo> =
+                    serde_json::from_value(evidence["execution"].clone())?;
+                let mut comparable_execution = info.execution.clone();
+                if let (Some(actual), Some(expected)) = (
+                    comparable_execution
+                        .as_mut()
+                        .and_then(|e| e.worker_execution_observation.as_mut()),
+                    expected_execution
+                        .as_ref()
+                        .and_then(|e| e.worker_execution_observation.as_ref()),
+                ) {
+                    for (actual_rank, expected_rank) in actual.ranks.iter_mut().zip(&expected.ranks)
+                    {
+                        if actual_rank.pid != 0 {
+                            actual_rank.pid = expected_rank.pid;
+                        }
+                    }
+                }
+                if info.n_vocab != loaded.n_vocab
+                    || (info.n_ctx_train != 0 && info.n_ctx_train != loaded.n_ctx_train)
+                    || tokens < u64::from(loaded.ctx_size)
+                    || comparable_execution != expected_execution
+                    || info.determinism.batch_invariant
+                        != evidence["determinism"]["batch_invariant"].as_bool()
+                    || !worker.component_healthy()
+                {
+                    return Err(EngineError::Vllm(
+                        "replacement isolated worker does not match the loaded execution contract"
+                            .to_owned(),
+                    ));
+                }
+                // Publishing only after validation preserves the pool's epoch and
+                // existing concurrent handles without replacing any healthy worker.
+                dispatch.write().unwrap_or_else(|p| p.into_inner())[index] = Arc::clone(&worker);
+                self.isolated_workers[index] = worker;
+                self.loaded_per_worker[index]["execution"] = json!(info.execution);
+                self.loaded_per_worker[index]["runtime_kv_token_capacity"] = json!(tokens);
+                self.loaded_per_worker[index]["runtime_full_context_capacity"] =
+                    json!(tokens / u64::from(loaded.ctx_size));
+            }
+            Ok(self.component_healthy())
         }
 
         fn process_ids(&self) -> Vec<u32> {

--- a/crates/mayhem-engine/src/lib.rs
+++ b/crates/mayhem-engine/src/lib.rs
@@ -1514,6 +1514,13 @@ pub trait ConcurrentGenerationBackend: Send + Sync {
     ) -> Result<GenerateOutput>;
 }
 
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum ComponentRecovery {
+    Unsupported,
+    Pending,
+    Recovered,
+}
+
 pub trait EngineBackend {
     fn backend_id(&self) -> &'static str;
     fn load(&mut self, config: LoadConfig) -> Result<LoadedModelInfo>;
@@ -1524,9 +1531,9 @@ pub trait EngineBackend {
         true
     }
     /// Repair failed components without interrupting healthy concurrent calls.
-    /// False means that a full reload is still required after requests drain.
-    fn recover_component(&mut self) -> Result<bool> {
-        Ok(false)
+    /// Poll without waiting for model loading; unsupported backends require a drained reload.
+    fn recover_component(&mut self) -> Result<ComponentRecovery> {
+        Ok(ComponentRecovery::Unsupported)
     }
     fn process_ids(&self) -> Vec<u32> {
         Vec::new()
@@ -8019,7 +8026,7 @@ mod vllm_backend {
         attach_worker_containment, effective_vllm_max_num_seqs, engine_worker_command,
         select_runtime_compatible_cuda_home, validate_load_config,
         validate_vllm_compilation_config, validate_vllm_kernel_backend, verify_artifact,
-        vllm_safetensors_payload_path, ArtifactFormat, CancellationToken,
+        vllm_safetensors_payload_path, ArtifactFormat, CancellationToken, ComponentRecovery,
         ConcurrentGenerationBackend, EngineBackend, EngineError, FinishReason, GenerateOutput,
         GenerateRequest, LoadConfig, LoadedModelInfo, Result, TokenChunk, TokenSink, Tokenization,
         UsageCounters, VllmGenerationTopology, WorkerContainment,
@@ -8055,6 +8062,7 @@ mod vllm_backend {
         python: PathBuf,
         worker: Option<Arc<VllmWorker>>,
         isolated_workers: Vec<Arc<VllmWorker>>,
+        isolated_recovery: Option<IsolatedWorkerRecovery>,
         loaded: Option<LoadedModelInfo>,
         next_id: Arc<AtomicU64>,
         memory_limit_bytes: Option<u64>,
@@ -8085,6 +8093,7 @@ mod vllm_backend {
                 python: python.into(),
                 worker: None,
                 isolated_workers: Vec::new(),
+                isolated_recovery: None,
                 loaded: None,
                 next_id: Arc::new(AtomicU64::new(1)),
                 memory_limit_bytes: None,
@@ -8162,6 +8171,7 @@ mod vllm_backend {
         }
 
         fn reset_isolated_workers(&mut self) {
+            self.isolated_recovery.take();
             for worker in self.isolated_workers.drain(..) {
                 worker.terminate();
             }
@@ -8485,6 +8495,26 @@ mod vllm_backend {
         }
     }
 
+    struct IsolatedWorkerRecovery {
+        index: usize,
+        worker: Option<Arc<VllmWorker>>,
+        loading: Option<JoinHandle<Result<WorkerLoadInfo>>>,
+        _permit: GenerationPermit,
+    }
+
+    impl Drop for IsolatedWorkerRecovery {
+        fn drop(&mut self) {
+            // A reload, shutdown, or rejected replacement owns and reaps the
+            // pending worker too; a successful publication takes it first.
+            if let Some(worker) = self.worker.take() {
+                worker.terminate();
+            }
+            if let Some(loading) = self.loading.take() {
+                let _ = loading.join();
+            }
+        }
+    }
+
     struct GenerationPermit {
         limiter: Arc<GenerationLimiter>,
         slot: usize,
@@ -8695,26 +8725,81 @@ mod vllm_backend {
                 }
         }
 
-        fn recover_component(&mut self) -> Result<bool> {
+        fn recover_component(&mut self) -> Result<ComponentRecovery> {
             if self.loaded_topology != Some(VllmGenerationTopology::IsolatedWorkers) {
-                return Ok(false);
+                return Ok(ComponentRecovery::Unsupported);
             }
             let Some(concurrent) = self.concurrent_generation.clone() else {
-                return Ok(false);
+                return Ok(ComponentRecovery::Unsupported);
             };
             let VllmGenerationDispatch::Isolated(dispatch) = &concurrent.dispatch else {
-                return Ok(false);
+                return Ok(ComponentRecovery::Unsupported);
             };
-            let loaded = self.loaded.as_ref().ok_or(EngineError::NotLoaded)?;
+            if let Some(recovery) = &self.isolated_recovery {
+                if !recovery
+                    .loading
+                    .as_ref()
+                    .is_some_and(JoinHandle::is_finished)
+                {
+                    return Ok(ComponentRecovery::Pending);
+                }
+                let mut recovery = self.isolated_recovery.take().unwrap();
+                let info = recovery.loading.take().unwrap().join().map_err(|_| {
+                    EngineError::Vllm("isolated worker recovery task panicked".to_owned())
+                })??;
+                let index = recovery.index;
+                let evidence = &self.loaded_per_worker[index];
+                let loaded = self.loaded.as_ref().ok_or(EngineError::NotLoaded)?;
+                let tokens = info.kv_cache_size_tokens.unwrap_or(0);
+                let expected_execution: Option<WorkerExecutionInfo> =
+                    serde_json::from_value(evidence["execution"].clone())?;
+                let mut comparable_execution = info.execution.clone();
+                if let (Some(actual), Some(expected)) = (
+                    comparable_execution
+                        .as_mut()
+                        .and_then(|e| e.worker_execution_observation.as_mut()),
+                    expected_execution
+                        .as_ref()
+                        .and_then(|e| e.worker_execution_observation.as_ref()),
+                ) {
+                    for (actual_rank, expected_rank) in actual.ranks.iter_mut().zip(&expected.ranks)
+                    {
+                        if actual_rank.pid != 0 {
+                            actual_rank.pid = expected_rank.pid;
+                        }
+                    }
+                }
+                let worker = recovery.worker.as_ref().unwrap();
+                if info.n_vocab != loaded.n_vocab
+                    || (info.n_ctx_train != 0 && info.n_ctx_train != loaded.n_ctx_train)
+                    || tokens < u64::from(loaded.ctx_size)
+                    || comparable_execution != expected_execution
+                    || info.determinism.batch_invariant
+                        != evidence["determinism"]["batch_invariant"].as_bool()
+                    || !worker.component_healthy()
+                {
+                    return Err(EngineError::Vllm(
+                        "replacement isolated worker does not match the loaded execution contract"
+                            .to_owned(),
+                    ));
+                }
+                let worker = recovery.worker.take().unwrap();
+                dispatch.write().unwrap_or_else(|p| p.into_inner())[index] = Arc::clone(&worker);
+                self.isolated_workers[index] = worker;
+                self.loaded_per_worker[index]["execution"] = json!(info.execution);
+                self.loaded_per_worker[index]["runtime_kv_token_capacity"] = json!(tokens);
+                self.loaded_per_worker[index]["runtime_full_context_capacity"] =
+                    json!(tokens / u64::from(loaded.ctx_size));
+            }
             for index in 0..self.isolated_workers.len() {
                 let old = &self.isolated_workers[index];
                 if old.component_healthy() {
                     continue;
                 }
-                // A failing call must finish releasing its route and slot first.
-                // Healthy slots remain leased and keep their original worker.
-                let Some(_permit) = concurrent.limiter.try_acquire_slot(index) else {
-                    return Ok(false);
+                // Wait for the failed request to release its own slot. Other
+                // slots remain usable through existing concurrent handles.
+                let Some(permit) = concurrent.limiter.try_acquire_slot(index) else {
+                    return Ok(ComponentRecovery::Pending);
                 };
                 let evidence = &self.loaded_per_worker[index];
                 let payload = evidence["load_payload"].clone();
@@ -8741,57 +8826,28 @@ mod vllm_backend {
                     self.cache_root.as_deref(),
                     execution_probe,
                 )?);
-                let info = worker.call_streaming::<WorkerLoadInfo>(
-                    self.next_request_id(),
-                    "load",
-                    payload,
-                    &mut |_| Ok(()),
-                    None,
-                    true,
-                    2,
-                )?;
-                let tokens = info.kv_cache_size_tokens.unwrap_or(0);
-                let expected_execution: Option<WorkerExecutionInfo> =
-                    serde_json::from_value(evidence["execution"].clone())?;
-                let mut comparable_execution = info.execution.clone();
-                if let (Some(actual), Some(expected)) = (
-                    comparable_execution
-                        .as_mut()
-                        .and_then(|e| e.worker_execution_observation.as_mut()),
-                    expected_execution
-                        .as_ref()
-                        .and_then(|e| e.worker_execution_observation.as_ref()),
-                ) {
-                    for (actual_rank, expected_rank) in actual.ranks.iter_mut().zip(&expected.ranks)
-                    {
-                        if actual_rank.pid != 0 {
-                            actual_rank.pid = expected_rank.pid;
-                        }
-                    }
-                }
-                if info.n_vocab != loaded.n_vocab
-                    || (info.n_ctx_train != 0 && info.n_ctx_train != loaded.n_ctx_train)
-                    || tokens < u64::from(loaded.ctx_size)
-                    || comparable_execution != expected_execution
-                    || info.determinism.batch_invariant
-                        != evidence["determinism"]["batch_invariant"].as_bool()
-                    || !worker.component_healthy()
-                {
-                    return Err(EngineError::Vllm(
-                        "replacement isolated worker does not match the loaded execution contract"
-                            .to_owned(),
-                    ));
-                }
-                // Publishing only after validation preserves the pool's epoch and
-                // existing concurrent handles without replacing any healthy worker.
-                dispatch.write().unwrap_or_else(|p| p.into_inner())[index] = Arc::clone(&worker);
-                self.isolated_workers[index] = worker;
-                self.loaded_per_worker[index]["execution"] = json!(info.execution);
-                self.loaded_per_worker[index]["runtime_kv_token_capacity"] = json!(tokens);
-                self.loaded_per_worker[index]["runtime_full_context_capacity"] =
-                    json!(tokens / u64::from(loaded.ctx_size));
+                let loading_worker = Arc::clone(&worker);
+                let id = self.next_request_id();
+                let loading = thread::spawn(move || {
+                    loading_worker.call_streaming::<WorkerLoadInfo>(
+                        id,
+                        "load",
+                        payload,
+                        &mut |_| Ok(()),
+                        None,
+                        true,
+                        2,
+                    )
+                });
+                self.isolated_recovery = Some(IsolatedWorkerRecovery {
+                    index,
+                    worker: Some(worker),
+                    loading: Some(loading),
+                    _permit: permit,
+                });
+                return Ok(ComponentRecovery::Pending);
             }
-            Ok(self.component_healthy())
+            Ok(ComponentRecovery::Recovered)
         }
 
         fn process_ids(&self) -> Vec<u32> {

--- a/crates/mayhem-engine/src/vllm_backend/isolated_tests.rs
+++ b/crates/mayhem-engine/src/vllm_backend/isolated_tests.rs
@@ -830,3 +830,134 @@ fn isolated_topology_transitions_preserve_shared_dispatch_and_gate_reload() {
     drop(backend);
     fixture.assert_exited(4);
 }
+
+#[test]
+fn isolated_recovery_replaces_only_dead_slot_while_sibling_generates() {
+    let fixture = Fixture::new(json!([plan(8192), plan(8192), plan(8192)]));
+    let mut backend = fixture.backend();
+    backend.load(fixture.config(2)).unwrap();
+    let concurrent = backend.concurrent_generation_backend().unwrap();
+    let healthy = generate(
+        Arc::clone(&concurrent),
+        "hold-live-recovery",
+        CancellationToken::new(),
+    );
+    let healthy_pid = fixture.read("seen-hold-live-recovery.json")["pid"]
+        .as_u64()
+        .unwrap();
+    assert_eq!(
+        fixture.read("spawn-0.json")["pid"].as_u64(),
+        Some(healthy_pid)
+    );
+    fs::write(fixture.root.join("fatal-1"), b"").unwrap();
+    let deadline = Instant::now() + Duration::from_secs(5);
+    while backend.component_healthy() {
+        assert!(Instant::now() < deadline);
+        thread::sleep(Duration::from_millis(10));
+    }
+    assert!(backend.recover_component().unwrap());
+    assert!(!healthy.is_finished());
+    assert_eq!(backend.process_ids()[0] as u64, healthy_pid);
+    let replacement_pid = fixture.read("spawn-2.json")["pid"].as_u64().unwrap();
+    let output = generate(
+        Arc::clone(&concurrent),
+        "after-live-recovery",
+        CancellationToken::new(),
+    )
+    .join()
+    .unwrap()
+    .unwrap();
+    assert_eq!(
+        output.text,
+        format!("{replacement_pid}:after-live-recovery")
+    );
+    fixture.release("hold-live-recovery");
+    assert_eq!(
+        healthy.join().unwrap().unwrap().text,
+        format!("{healthy_pid}:hold-live-recovery")
+    );
+    assert!(backend.component_healthy());
+    drop(concurrent);
+    drop(backend);
+    fixture.assert_exited(3);
+}
+
+#[test]
+fn isolated_recovery_rejects_reduced_capacity_and_retries_without_touching_sibling() {
+    let fixture = Fixture::new(json!([plan(8192), plan(8192), plan(1024), plan(8192)]));
+    let mut backend = fixture.backend();
+    backend.load(fixture.config(2)).unwrap();
+    let concurrent = backend.concurrent_generation_backend().unwrap();
+    let healthy = generate(
+        Arc::clone(&concurrent),
+        "hold-invalid-recovery",
+        CancellationToken::new(),
+    );
+    let healthy_pid = fixture.read("seen-hold-invalid-recovery.json")["pid"]
+        .as_u64()
+        .unwrap();
+    fs::write(fixture.root.join("fatal-1"), b"").unwrap();
+    let deadline = Instant::now() + Duration::from_secs(5);
+    while backend.component_healthy() {
+        assert!(Instant::now() < deadline);
+        thread::sleep(Duration::from_millis(10));
+    }
+    assert!(backend
+        .recover_component()
+        .unwrap_err()
+        .to_string()
+        .contains("execution contract"));
+    assert!(!healthy.is_finished());
+    assert_eq!(backend.process_ids()[0] as u64, healthy_pid);
+    assert!(!backend.component_healthy());
+    assert!(backend.recover_component().unwrap());
+    assert!(!healthy.is_finished());
+    assert!(generate(
+        Arc::clone(&concurrent),
+        "after-recovery-retry",
+        CancellationToken::new()
+    )
+    .join()
+    .unwrap()
+    .unwrap()
+    .text
+    .ends_with(":after-recovery-retry"));
+    fixture.release("hold-invalid-recovery");
+    assert!(healthy.join().unwrap().is_ok());
+    drop(concurrent);
+    drop(backend);
+    fixture.assert_exited(4);
+}
+
+#[test]
+fn isolated_recovery_updates_execution_process_identity() {
+    let with_pid = |pid| {
+        let mut value = plan(8192);
+        value["load"]["result"]["execution"] = json!({
+            "worker_execution_observation": {
+                "source": "vllm-worker-rpc", "rank_count": 1, "world_size": 1,
+                "ranks": [{"rank": 0, "local_rank": 0, "world_size": 1, "pid": pid,
+                    "compilation_mode": 0, "cudagraph_mode": "NONE"}]
+            }
+        });
+        value
+    };
+    let fixture = Fixture::new(json!([with_pid(100), with_pid(101), with_pid(200)]));
+    let mut backend = fixture.backend();
+    backend.load(fixture.config(2)).unwrap();
+    fs::write(fixture.root.join("fatal-0"), b"").unwrap();
+    let deadline = Instant::now() + Duration::from_secs(5);
+    while backend.component_healthy() {
+        assert!(Instant::now() < deadline);
+        thread::sleep(Duration::from_millis(10));
+    }
+    assert!(backend.recover_component().unwrap());
+    let evidence = backend.loaded_backend_evidence().unwrap();
+    assert_eq!(
+        evidence["generation"]["per_worker"][0]["execution"]["worker_execution_observation"]
+            ["ranks"][0]["pid"],
+        200
+    );
+    drop(backend);
+    fixture.assert_exited(3);
+}

--- a/crates/mayhem-engine/src/vllm_backend/isolated_tests.rs
+++ b/crates/mayhem-engine/src/vllm_backend/isolated_tests.rs
@@ -65,6 +65,8 @@ while time.monotonic() < deadline:
         break
     if op == 'load':
         record(f'load-{index}.json', request)
+        while plan.get('hold_load') and not (root / f'release-load-{index}').exists():
+            time.sleep(0.01)
         record(f'loaded-{index}.json', True)
         if plan.get('remove_executable'):
             Path(__file__).unlink()
@@ -855,7 +857,10 @@ fn isolated_recovery_replaces_only_dead_slot_while_sibling_generates() {
         assert!(Instant::now() < deadline);
         thread::sleep(Duration::from_millis(10));
     }
-    assert!(backend.recover_component().unwrap());
+    assert_eq!(
+        finish_recovery(&mut backend).unwrap(),
+        ComponentRecovery::Recovered
+    );
     assert!(!healthy.is_finished());
     assert_eq!(backend.process_ids()[0] as u64, healthy_pid);
     let replacement_pid = fixture.read("spawn-2.json")["pid"].as_u64().unwrap();
@@ -902,15 +907,17 @@ fn isolated_recovery_rejects_reduced_capacity_and_retries_without_touching_sibli
         assert!(Instant::now() < deadline);
         thread::sleep(Duration::from_millis(10));
     }
-    assert!(backend
-        .recover_component()
+    assert!(finish_recovery(&mut backend)
         .unwrap_err()
         .to_string()
         .contains("execution contract"));
     assert!(!healthy.is_finished());
     assert_eq!(backend.process_ids()[0] as u64, healthy_pid);
     assert!(!backend.component_healthy());
-    assert!(backend.recover_component().unwrap());
+    assert_eq!(
+        finish_recovery(&mut backend).unwrap(),
+        ComponentRecovery::Recovered
+    );
     assert!(!healthy.is_finished());
     assert!(generate(
         Arc::clone(&concurrent),
@@ -951,13 +958,70 @@ fn isolated_recovery_updates_execution_process_identity() {
         assert!(Instant::now() < deadline);
         thread::sleep(Duration::from_millis(10));
     }
-    assert!(backend.recover_component().unwrap());
+    assert_eq!(
+        finish_recovery(&mut backend).unwrap(),
+        ComponentRecovery::Recovered
+    );
     let evidence = backend.loaded_backend_evidence().unwrap();
     assert_eq!(
         evidence["generation"]["per_worker"][0]["execution"]["worker_execution_observation"]
             ["ranks"][0]["pid"],
         200
     );
+    drop(backend);
+    fixture.assert_exited(3);
+}
+
+fn finish_recovery(backend: &mut VllmBackend) -> Result<ComponentRecovery> {
+    let deadline = Instant::now() + Duration::from_secs(5);
+    loop {
+        let status = backend.recover_component()?;
+        if status != ComponentRecovery::Pending {
+            return Ok(status);
+        }
+        assert!(Instant::now() < deadline, "recovery timed out");
+        thread::sleep(Duration::from_millis(10));
+    }
+}
+
+#[test]
+fn isolated_recovery_loading_is_nonblocking_and_drop_reaps_pending_worker() {
+    let mut slow = plan(8192);
+    slow["hold_load"] = json!(true);
+    let fixture = Fixture::new(json!([plan(8192), plan(8192), slow]));
+    let mut backend = fixture.backend();
+    backend.load(fixture.config(2)).unwrap();
+    let cancel = CancellationToken::new();
+    let healthy = generate(
+        backend.concurrent_generation_backend().unwrap(),
+        "hold-loading",
+        cancel.clone(),
+    );
+    fixture.read("seen-hold-loading.json");
+    fs::write(fixture.root.join("fatal-1"), b"").unwrap();
+    let deadline = Instant::now() + Duration::from_secs(5);
+    while backend.component_healthy() {
+        assert!(Instant::now() < deadline);
+        thread::sleep(Duration::from_millis(10));
+    }
+    assert_eq!(
+        backend.recover_component().unwrap(),
+        ComponentRecovery::Pending
+    );
+    fixture.read("load-2.json");
+    let start = Instant::now();
+    assert_eq!(
+        backend.recover_component().unwrap(),
+        ComponentRecovery::Pending
+    );
+    assert!(start.elapsed() < Duration::from_millis(100));
+    // Keep the replacement blocked and cancel a healthy request through the
+    // original handle before shutting down the still-loading backend.
+    cancel.cancel();
+    assert!(matches!(
+        healthy.join().unwrap(),
+        Err(EngineError::Cancelled)
+    ));
     drop(backend);
     fixture.assert_exited(3);
 }


### PR DESCRIPTION
When one isolated vLLM EngineCore dies, the provider currently stops admitting requests and waits for every healthy session to finish before reloading the entire pool. A long sibling request can therefore keep the model unavailable for many minutes.

Replace only the failed worker after its request releases its slot. Load the replacement in the background so session handling and cancellation remain responsive, then validate its original execution profile and full-context capacity before publishing it to existing concurrent handles. Healthy workers retain their processes and generation epoch. Backends without isolated recovery retain the drained reload path; shutdown also reaps a pending replacement.

Validation: 63 focused engine tests and the provider-loop killed-child regression pass; CLI compilation passes. On the actual Qwen GPU with two full-context MTP workers, a controlled idle EngineCore failure was repaired while the healthy request advanced from 38 to 4,501 tokens. The existing handle then generated on the replacement. Maximum recovery poll time was 208 ms; replacement and follow-up took 310 seconds under concurrent GPU load. The original CUDA illegal-access trigger remains unproven; this change fixes the resulting recovery outage.
