### PR TITLE
Stream text, reasoning and tool arguments during generation

### DIFF
--- a/crates/mayhem-cli/src/main.rs
+++ b/crates/mayhem-cli/src/main.rs
@@ -89376,6 +89376,20 @@ fn provider_reasoning_output_mode(
     }
 }
 
+fn provider_constrained_reasoning_output_mode(
+    mode: ProviderReasoningOutputMode,
+    json_grammar_enforced: bool,
+) -> ProviderReasoningOutputMode {
+    // A whole-response JSON grammar cannot emit the prefilled thinking close
+    // marker. Its JSON is the answer/tool call, not an unfinished thought. This
+    // changes presentation only; the prompt and the backend grammar stay intact.
+    if json_grammar_enforced && mode == ProviderReasoningOutputMode::StripPrefilled {
+        ProviderReasoningOutputMode::StripTagged
+    } else {
+        mode
+    }
+}
+
 fn provider_reasoning_speciality_enabled(request: &GenerateRequest) -> Option<bool> {
     request.speciality_parameters.iter().find_map(|speciality| {
         if !provider_reasoning_speciality_control(&speciality.name, &speciality.native_path) {
@@ -90064,6 +90078,8 @@ fn provider_engine_session_response_with_sampling_bounded(
         request.grammar.as_ref(),
         Some(GrammarSpec::ToolCall { .. } | GrammarSpec::JsonSchema { .. })
     );
+    let reasoning_output_mode =
+        provider_constrained_reasoning_output_mode(reasoning_output_mode, json_grammar_enforced);
     let mut reasoning_stream_filter =
         ProviderReasoningOutputFilter::with_delimiters(reasoning_output_mode, reasoning_delimiters);
     let mut tool_stream_filter = tool_mode.as_ref().map(|mode|

--- a/crates/mayhem-cli/src/main.rs
+++ b/crates/mayhem-cli/src/main.rs
@@ -5,6 +5,7 @@ mod endpoint_calibration;
 mod gemma4;
 mod intercom_runtime;
 mod python_runtime;
+mod provider_output_stream;
 mod release_bundle;
 
 #[cfg(test)]
@@ -82371,6 +82372,7 @@ struct ProviderSessionLiveStreamState {
     next_index: u64,
     receipt_seq: u64,
     last_checkpoint_metered_units: u64,
+    last_checkpoint_reasoning_units: u64,
     delivered_metered_units: u64,
     reasoning_units: u64,
     prompt_tokens: u64,
@@ -82389,6 +82391,7 @@ struct ProviderSessionLiveStream<'a> {
     next_index: u64,
     receipt_seq: u64,
     last_checkpoint_metered_units: u64,
+    last_checkpoint_reasoning_units: u64,
     first_ttft_ms: Option<u64>,
     first_token_at: Option<Instant>,
     last_token_at: Option<Instant>,
@@ -82398,6 +82401,7 @@ struct ProviderSessionLiveStream<'a> {
     streamed_any: bool,
     pending_text: String,
     pending_hidden_reasoning: String,
+    pending_tool_deltas: Vec<Value>,
     pending_token_ids: Vec<i32>,
     visible_text: String,
     hidden_reasoning: String,
@@ -82648,6 +82652,7 @@ impl<'a> ProviderSessionLiveStream<'a> {
             next_index: 0,
             receipt_seq: 1,
             last_checkpoint_metered_units: 0,
+            last_checkpoint_reasoning_units: 0,
             first_ttft_ms: None,
             first_token_at: None,
             last_token_at: None,
@@ -82657,6 +82662,7 @@ impl<'a> ProviderSessionLiveStream<'a> {
             streamed_any: false,
             pending_text: String::new(),
             pending_hidden_reasoning: String::new(),
+            pending_tool_deltas: Vec::new(),
             pending_token_ids: Vec::new(),
             visible_text: String::new(),
             hidden_reasoning: String::new(),
@@ -82737,10 +82743,26 @@ impl<'a> ProviderSessionLiveStream<'a> {
                 })
             })?;
             self.last_checkpoint_metered_units = self.delivered_metered_units;
+            self.last_checkpoint_reasoning_units = metered_output_units("", &self.hidden_reasoning, &[]);
             self.receipt_seq = self.receipt_seq.saturating_add(1);
         }
         self.poll_client_disconnect()?;
         Ok(())
+    }
+
+    fn tool_stream_id(&self, index: usize) -> String {
+        format!("call-{}", stable_value_hash(&json!({"request": self.request_id, "index": index})))
+    }
+
+    fn append_tool_deltas(&mut self, deltas: Vec<Value>) {
+        for mut delta in deltas {
+            if delta.get("name").is_some() {
+                if let Some(index) = delta.get("index").and_then(Value::as_u64) {
+                    delta["id"] = json!(self.tool_stream_id(index as usize));
+                }
+            }
+            self.pending_tool_deltas.push(delta);
+        }
     }
 
     fn append_filtered_text(&mut self, filtered: ProviderReasoningFilteredText) {
@@ -82790,10 +82812,10 @@ impl<'a> ProviderSessionLiveStream<'a> {
         } else {
             ReceiptUsage::text(self.prompt_tokens, self.last_checkpoint_metered_units)
         };
-        let usage_attribution = if self.last_checkpoint_metered_units == 0 {
+        let usage_attribution = if self.last_checkpoint_reasoning_units == 0 {
             BTreeMap::new()
         } else {
-            provider_reasoning_usage_attribution(&self.hidden_reasoning)
+            BTreeMap::from([("reasoning_output_tokens".to_owned(), self.last_checkpoint_reasoning_units)])
         };
         (usage, usage_attribution, self.receipt_seq)
     }
@@ -82807,6 +82829,7 @@ impl<'a> ProviderSessionLiveStream<'a> {
         if self.pending_text.is_empty()
             && self.pending_hidden_reasoning.is_empty()
             && self.pending_token_ids.is_empty()
+            && self.pending_tool_deltas.is_empty()
         {
             return Ok(());
         }
@@ -82817,22 +82840,42 @@ impl<'a> ProviderSessionLiveStream<'a> {
             self.active.session_id,
             self.request_id
         ));
-        let frame = json!({
-            "t": "s.delta",
-            "rid": self.request_id,
-            "i": self.next_index,
-            "d": &self.pending_text,
-            "reasoning_evidence_delta": &self.pending_hidden_reasoning,
-            "token_ids_delta": &self.pending_token_ids,
-            "tools": null,
-            "fin": null,
-        });
+        // Argument values can become decidable in one large chunk (for
+        // example a union-typed XML parameter). Split the presentation into
+        // bounded protocol frames, keeping call identity on its first fragment.
+        let max_frame_bytes = provider_session_max_frame_bytes();
+        let mut tool_fragments = Vec::new();
+        for delta in &self.pending_tool_deltas {
+            let args = delta.get("arguments").and_then(Value::as_str).unwrap_or_default();
+            let parts = provider_stream_parts(args, (max_frame_bytes / 12).max(1));
+            if parts.is_empty() { tool_fragments.push(delta.clone()); }
+            for (part_index, part) in parts.iter().enumerate() {
+                let mut fragment = if part_index == 0 { delta.clone() }
+                    else { json!({"index":delta["index"]}) };
+                fragment["arguments"] = json!(part);
+                tool_fragments.push(fragment);
+            }
+        }
+        let frames = tool_fragments.len().max(1);
         tokio::task::block_in_place(|| {
             tokio::runtime::Handle::current().block_on(async {
-                self.bridge
-                    .session_send(&self.active.remote, &self.active.session_id, frame)
-                    .await
-                    .context("sending live token s.delta")
+                for part_index in 0..frames {
+                    let first = part_index == 0;
+                    let frame = json!({
+                        "t":"s.delta", "rid":self.request_id,
+                        "i":self.next_index + part_index as u64,
+                        "d":if first { self.pending_text.as_str() } else { "" },
+                        "reasoning_evidence_delta":if first { self.pending_hidden_reasoning.as_str() } else { "" },
+                        "token_ids_delta":if first { self.pending_token_ids.as_slice() } else { &[] },
+                        "tool_calls_delta":tool_fragments.get(part_index).map(|delta| vec![delta]).unwrap_or_default(),
+                        "tools":null,"fin":null,
+                    });
+                    ensure!(provider_session_frame_json_len(&frame)? <= max_frame_bytes,
+                        "live output delta exceeds session frame limit");
+                    self.bridge.session_send(&self.active.remote, &self.active.session_id, frame)
+                        .await.context("sending live output s.delta")?;
+                }
+                Ok::<(), anyhow::Error>(())
             })
         })?;
         self.visible_text.push_str(&self.pending_text);
@@ -82844,7 +82887,8 @@ impl<'a> ProviderSessionLiveStream<'a> {
         self.pending_text.clear();
         self.pending_hidden_reasoning.clear();
         self.pending_token_ids.clear();
-        self.next_index = self.next_index.saturating_add(1);
+        self.pending_tool_deltas.clear();
+        self.next_index = self.next_index.saturating_add(frames as u64);
         Ok(())
     }
 
@@ -82894,47 +82938,11 @@ impl<'a> ProviderSessionLiveStream<'a> {
     }
 
     fn send_client_disconnect_receipt(&mut self) -> Result<()> {
-        if self.delivered_metered_units == 0
-            || self.delivered_metered_units == self.last_checkpoint_metered_units
-        {
-            return Ok(());
-        }
-        let usage = ReceiptUsage::text(self.prompt_tokens, self.delivered_metered_units);
-        let usage_attribution = provider_reasoning_usage_attribution(&self.hidden_reasoning);
-        let receipt = provider_session_receipt_for_usage_attribution(
-            self.terms,
-            self.active,
-            self.body,
-            usage,
-            usage_attribution,
-            self.receipt_seq,
-            false,
-            self.runtime_keypair,
-        )
-        .context("building client-disconnect provider session receipt")?;
-        tokio::task::block_in_place(|| {
-            tokio::runtime::Handle::current().block_on(async {
-                send_provider_session_receipt_frame(
-                    self.bridge,
-                    self.active,
-                    self.request_id,
-                    &receipt,
-                    "client_disconnect",
-                )
-                .await?;
-                let _ = wait_for_provider_receipt_ack(
-                    self.bridge,
-                    self.active,
-                    &receipt,
-                    Duration::from_secs(5),
-                    None,
-                )
-                .await;
-                Ok::<(), anyhow::Error>(())
-            })
-        })?;
-        self.last_checkpoint_metered_units = self.delivered_metered_units;
-        self.receipt_seq = self.receipt_seq.saturating_add(1);
+        let (usage, attribution, seq) = self.cancellation_receipt_state();
+        tokio::task::block_in_place(|| tokio::runtime::Handle::current().block_on(async {
+            settle_cancelled_provider_session(self.bridge, self.active, self.request_id,
+                self.terms, self.body, usage, attribution, seq, self.runtime_keypair).await
+        }))?;
         Ok(())
     }
 
@@ -82943,6 +82951,7 @@ impl<'a> ProviderSessionLiveStream<'a> {
             next_index: self.next_index,
             receipt_seq: self.receipt_seq,
             last_checkpoint_metered_units: self.last_checkpoint_metered_units,
+            last_checkpoint_reasoning_units: self.last_checkpoint_reasoning_units,
             delivered_metered_units: self.delivered_metered_units,
             reasoning_units: metered_output_units("", &self.hidden_reasoning, &[]),
             prompt_tokens: self.prompt_tokens,
@@ -83055,11 +83064,7 @@ async fn send_provider_session_output(
     if live_stream_state.is_none() {
         let max_frame_bytes = provider_session_max_frame_bytes();
         let delta_bytes = provider_session_text_delta_bytes(max_frame_bytes);
-        let parts = if output.tools.is_empty() {
-            provider_stream_parts(&output.content, delta_bytes)
-        } else {
-            Vec::new()
-        };
+        let parts = provider_stream_parts(&output.content, delta_bytes);
         let reasoning_parts = provider_stream_parts(&output.reasoning_evidence, delta_bytes);
         let token_part_count = output
             .token_ids
@@ -83226,38 +83231,12 @@ async fn send_provider_client_disconnect_receipt_if_requested(
     if !provider_session_client_disconnect_requested(bridge, active).await? {
         return Ok(());
     }
-    if state.delivered_metered_units > 0
-        && state.delivered_metered_units != state.last_checkpoint_metered_units
-    {
-        let usage = ReceiptUsage::text(state.prompt_tokens, state.delivered_metered_units);
-        let usage_attribution = if state.reasoning_units == 0 {
-            BTreeMap::new()
-        } else {
-            BTreeMap::from([("reasoning_output_tokens".to_owned(), state.reasoning_units)])
-        };
-        let receipt = provider_session_receipt_for_usage_attribution(
-            terms,
-            active,
-            body,
-            usage,
-            usage_attribution,
-            state.receipt_seq,
-            false,
-            runtime_keypair,
-        )
-        .context("building client-disconnect provider session receipt")?;
-        send_provider_session_receipt_frame(
-            bridge,
-            active,
-            request_id,
-            &receipt,
-            "client_disconnect",
-        )
-        .await?;
-        let _ =
-            wait_for_provider_receipt_ack(bridge, active, &receipt, Duration::from_secs(5), None)
-                .await;
-    }
+    let usage = if state.last_checkpoint_metered_units == 0 { ReceiptUsage::default() }
+        else { ReceiptUsage::text(state.prompt_tokens, state.last_checkpoint_metered_units) };
+    let attribution = if state.last_checkpoint_reasoning_units == 0 { BTreeMap::new() }
+        else { BTreeMap::from([("reasoning_output_tokens".to_owned(), state.last_checkpoint_reasoning_units)]) };
+    settle_cancelled_provider_session(bridge, active, request_id, terms, body, usage,
+        attribution, state.receipt_seq, runtime_keypair).await?;
     bail!("{PROVIDER_SESSION_CLIENT_DISCONNECT_ABORT}");
 }
 
@@ -84081,12 +84060,12 @@ async fn wait_for_provider_receipt_ack_inner(
     cancellation: Option<&CancellationToken>,
     settling_cancellation: bool,
 ) -> Result<ReceiptAck> {
-    let deadline = Instant::now() + wait;
+    let mut deadline = Instant::now() + wait;
+    let mut cancellation_drain = false;
     loop {
-        if let Some(cancellation) = cancellation {
-            cancellation
-                .check()
-                .context("provider receipt acknowledgement wait cancelled")?;
+        if cancellation.is_some_and(CancellationToken::is_cancelled) && !cancellation_drain {
+            cancellation_drain = true;
+            deadline = deadline.min(Instant::now() + Duration::from_millis(500));
         }
         let remaining = deadline.saturating_duration_since(Instant::now());
         if remaining.is_zero() {
@@ -84136,10 +84115,15 @@ async fn wait_for_provider_receipt_ack_inner(
                         return Ok(receipt_ack);
                     }
                     Some("s.close")
-                        if settling_cancellation
+                        if (settling_cancellation || cancellation.is_some())
                             && frame.get("reason").and_then(Value::as_str)
                                 == Some("client_disconnect") =>
                     {
+                        if !settling_cancellation && !cancellation_drain {
+                            if let Some(token) = cancellation { token.cancel(); }
+                            cancellation_drain = true;
+                            deadline = deadline.min(Instant::now() + Duration::from_millis(500));
+                        }
                         // The liveness monitor has its own subscription. Its
                         // cancellation broadcast can still be queued on this
                         // connection ahead of the final receipt acknowledgement.
@@ -90082,6 +90066,8 @@ fn provider_engine_session_response_with_sampling_bounded(
     );
     let mut reasoning_stream_filter =
         ProviderReasoningOutputFilter::with_delimiters(reasoning_output_mode, reasoning_delimiters);
+    let mut tool_stream_filter = tool_mode.as_ref().map(|mode|
+        provider_output_stream::OutputStream::new(mode.strategy, mode.tools.clone()));
     let mut token_ids = Vec::new();
     let mut artifact_chunks = ProviderSessionArtifactCollector::configured();
     // Existing text models keep the established request-text estimate. A signed
@@ -90092,19 +90078,18 @@ fn provider_engine_session_response_with_sampling_bounded(
         .generate_with_artifacts(
             request,
             &mut |chunk: mayhem_engine::TokenChunk| {
-                if tool_mode.is_none() {
-                    if let Some(stream) = live_stream.as_deref_mut() {
-                        let filtered = reasoning_stream_filter.push_split(&chunk.text);
-                        let mut visible_chunk = chunk.clone();
-                        visible_chunk.text = filtered.visible;
-                        stream
-                            .on_token(visible_chunk, &filtered.hidden, estimated_prompt_tokens)
-                            .map_err(|err| {
-                                mayhem_engine::EngineError::InvalidConfig(format!(
-                                    "provider live stream failed: {err:#}"
-                                ))
-                            })?;
-                    }
+                if let Some(stream) = live_stream.as_deref_mut() {
+                    let filtered = reasoning_stream_filter.push_split(&chunk.text);
+                    let mut visible_chunk = chunk.clone();
+                    visible_chunk.text = if let Some(filter) = tool_stream_filter.as_mut() {
+                        let delta = filter.push(&filtered.visible);
+                        stream.append_tool_deltas(delta.tools);
+                        delta.text
+                    } else { filtered.visible };
+                    stream.on_token(visible_chunk, &filtered.hidden,
+                        protocol_prompt_tokens.unwrap_or(estimated_prompt_tokens))
+                        .map_err(|err| mayhem_engine::EngineError::InvalidConfig(
+                            format!("provider live stream failed: {err:#}")))?;
                 }
                 token_ids.push(chunk.token_id);
                 Ok(())
@@ -90113,16 +90098,17 @@ fn provider_engine_session_response_with_sampling_bounded(
             cancellation,
         )
         .context("generating provider session response with mayhem-engine")?;
-    if tool_mode.is_none() {
-        let trailing = reasoning_stream_filter.finish_split();
-        if !trailing.visible.is_empty() || !trailing.hidden.is_empty() {
-            if let Some(stream) = live_stream.as_deref_mut() {
-                stream.append_filtered_text(trailing);
-            }
+    if let Some(stream) = live_stream.as_deref_mut() {
+        let mut trailing = reasoning_stream_filter.finish_split();
+        if let Some(filter) = tool_stream_filter.as_mut() {
+            let delta = filter.push(&trailing.visible);
+            stream.append_tool_deltas(delta.tools);
+            trailing.visible = delta.text;
         }
+        stream.append_filtered_text(trailing);
     }
     let artifacts = artifact_chunks.finish()?;
-    let tools = tool_mode
+    let mut tools = tool_mode
         .as_ref()
         .and_then(|mode| {
             provider_engine_tool_call_outputs_after_reasoning(
@@ -90154,6 +90140,17 @@ fn provider_engine_session_response_with_sampling_bounded(
             output.text.trim()
         )));
     }
+    let streamed_content = if let (Some(stream), Some(filter)) =
+        (live_stream.as_deref_mut(), tool_stream_filter.as_mut()) {
+        ensure!(filter.emitted_count() <= tools.len(),
+            "provider streamed a tool call that failed final validation");
+        for (index, call) in tools.iter_mut().enumerate().take(filter.emitted_count()) {
+            call["id"] = json!(stream.tool_stream_id(index));
+        }
+        let tail = filter.finish_text(!tools.is_empty());
+        stream.append_filtered_text(ProviderReasoningFilteredText { visible: tail, hidden: String::new() });
+        Some(filter.text.clone())
+    } else { None };
     let completion_tokens = u64::from(output.usage.completion_tokens);
     let reasoning_tokens = u64::from(output.usage.reasoning_tokens).min(completion_tokens);
     let vision_tokens = u64::from(output.usage.vision_tokens);
@@ -90184,11 +90181,14 @@ fn provider_engine_session_response_with_sampling_bounded(
     );
     Ok(ProviderSessionOutput {
         usage: provider_chat_receipt_usage(request_body, billed_prompt_tokens, completion_tokens),
-        content: if tools.is_empty() {
+        content: streamed_content.unwrap_or_else(|| if tools.is_empty() {
             filtered_output.visible
         } else {
-            String::new()
-        },
+            // Native Qwen permits commentary preceding a tool call. Preserve it
+            // in both delivery modes so usage does not depend on stream=true.
+            filtered_output.visible.split_once("<tool_call>")
+                .map(|(text, _)| text.to_owned()).unwrap_or_default()
+        }),
         reasoning_evidence: filtered_output.hidden,
         tools,
         embeddings: None,
@@ -110959,12 +110959,14 @@ printf '{"kind":"nvidia_nvtrust_offline_jwt","evidence":"boot:%s:%s","platform_i
         use futures_util::{SinkExt, StreamExt};
         use tokio_tungstenite::tungstenite::Message;
 
-        for (settling, reason, valid_signature, send_ack, succeeds) in [
-            (false, "client_disconnect", true, true, false),
-            (true, "client_disconnect", true, true, true),
-            (true, "shutdown", true, true, false),
-            (true, "client_disconnect", false, true, false),
-            (true, "client_disconnect", true, false, false),
+        for (settling, cancellable, reason, valid_signature, send_ack, succeeds) in [
+            (false, false, "client_disconnect", true, true, false),
+            (true, false, "client_disconnect", true, true, true),
+            (true, false, "shutdown", true, true, false),
+            (true, false, "client_disconnect", false, true, false),
+            (true, false, "client_disconnect", true, false, false),
+            (false, true, "client_disconnect", true, true, true),
+            (false, true, "client_disconnect", true, false, false),
         ] {
             let mut terms = test_provider_session_terms();
             terms.min_session_au = 37;
@@ -111029,12 +111031,14 @@ printf '{"kind":"nvidia_nvtrust_offline_jwt","evidence":"boot:%s:%s","platform_i
             )
             .await
             .unwrap();
+            let cancellation = CancellationToken::new();
+            if cancellable { cancellation.cancel(); }
             let result = wait_for_provider_receipt_ack_inner(
                 &mut bridge,
                 &active,
                 &receipt,
                 Duration::from_millis(150),
-                None,
+                cancellable.then_some(&cancellation),
                 settling,
             )
             .await;

--- a/crates/mayhem-cli/src/provider_output_stream.rs
+++ b/crates/mayhem-cli/src/provider_output_stream.rs
@@ -1,0 +1,581 @@
+//! Incremental presentation of engine output. Prompt construction, token IDs and
+//! the authoritative, schema-checked final tool parser remain unchanged.
+use super::{ProviderEngineToolStrategy, ToolSpec, provider_qwen_xml_parameter_value};
+use serde_json::{Value, json};
+
+#[derive(Default, Debug)]
+pub(super) struct Delta {
+    pub text: String,
+    pub tools: Vec<Value>,
+}
+
+pub(super) struct OutputStream {
+    strategy: ProviderEngineToolStrategy,
+    tools: Vec<ToolSpec>,
+    pending: String,
+    tool_text: String,
+    in_tools: bool,
+    json_probe: bool,
+    emitted: Vec<(String, String)>,
+    pub text: String,
+}
+
+impl OutputStream {
+    pub fn new(strategy: ProviderEngineToolStrategy, tools: Vec<ToolSpec>) -> Self {
+        Self {
+            strategy,
+            tools,
+            pending: String::new(),
+            tool_text: String::new(),
+            in_tools: false,
+            json_probe: true,
+            emitted: Vec::new(),
+            text: String::new(),
+        }
+    }
+
+    pub fn push(&mut self, text: &str) -> Delta {
+        let mut delta = Delta::default();
+        if !self.in_tools {
+            self.pending.push_str(text);
+            let trimmed = self.pending.trim_start();
+            // JSON tool envelopes are recognizable before their arguments. Hold
+            // only that prefix; ordinary prose never waits for generation end.
+            if self.json_probe && (trimmed.is_empty() || trimmed.starts_with(['{', '['])) {
+                if trimmed.is_empty() {
+                    return delta;
+                }
+                match json_tool_prefix(trimmed) {
+                    Some(true) => {
+                        self.in_tools = true;
+                    }
+                    Some(false) => {
+                        self.json_probe = false;
+                    }
+                    None => return delta,
+                }
+            } else {
+                self.json_probe = false;
+            }
+            if !self.in_tools {
+                let marker = match self.strategy {
+                    ProviderEngineToolStrategy::QwenFunctionXml => "<tool_call>",
+                    ProviderEngineToolStrategy::GemmaFunctionCall => "<|tool_call>call:",
+                    _ => "",
+                };
+                if !marker.is_empty() {
+                    if let Some(index) = self.pending.find(marker) {
+                        delta.text = self.pending[..index].to_owned();
+                        self.pending.drain(..index);
+                        self.in_tools = true;
+                    } else {
+                        let retained = suffix_prefix_len(&self.pending, marker);
+                        let end = self.pending.len() - retained;
+                        delta.text = self.pending[..end].to_owned();
+                        self.pending.drain(..end);
+                    }
+                } else {
+                    delta.text = std::mem::take(&mut self.pending);
+                }
+            }
+            if self.in_tools {
+                self.tool_text.push_str(&std::mem::take(&mut self.pending));
+            }
+        } else {
+            self.tool_text.push_str(text);
+        }
+        self.text.push_str(&delta.text);
+        if self.in_tools {
+            let previews = if self.tool_text.trim_start().starts_with(['{', '[']) {
+                json_previews(&self.tool_text)
+            } else {
+                match self.strategy {
+                    ProviderEngineToolStrategy::QwenFunctionXml => {
+                        qwen_previews(&self.tool_text, &self.tools)
+                    }
+                    ProviderEngineToolStrategy::GemmaFunctionCall => {
+                        gemma_previews(&self.tool_text)
+                    }
+                    _ => Vec::new(),
+                }
+            };
+            for (index, (name, arguments)) in previews.into_iter().enumerate() {
+                // Unadvertised names never become public calls. The existing
+                // final parser still validates the entire call and its schema.
+                if !self.tools.iter().any(|tool| tool.name == name) {
+                    break;
+                }
+                if index == self.emitted.len() {
+                    delta
+                        .tools
+                        .push(json!({"index":index,"name":name,"arguments":arguments}));
+                    self.emitted.push((name, arguments));
+                } else if let Some((old_name, old_args)) = self.emitted.get_mut(index) {
+                    if *old_name == name && arguments.starts_with(old_args.as_str()) {
+                        let suffix = &arguments[old_args.len()..];
+                        if !suffix.is_empty() {
+                            delta.tools.push(json!({"index":index,"arguments":suffix}));
+                            *old_args = arguments;
+                        }
+                    }
+                }
+            }
+        }
+        delta
+    }
+
+    pub fn finish_text(&mut self, has_tools: bool) -> String {
+        let tail = if has_tools {
+            String::new()
+        } else if self.in_tools && self.emitted.is_empty() {
+            std::mem::take(&mut self.tool_text)
+        } else {
+            std::mem::take(&mut self.pending)
+        };
+        self.text.push_str(&tail);
+        tail
+    }
+
+    pub fn emitted_count(&self) -> usize {
+        self.emitted.len()
+    }
+}
+
+fn suffix_prefix_len(text: &str, marker: &str) -> usize {
+    (1..marker.len())
+        .rev()
+        .find(|length| text.ends_with(&marker[..*length]))
+        .unwrap_or(0)
+}
+
+fn escaped(text: &str) -> String {
+    let value = serde_json::to_string(text).expect("string serialization");
+    value[1..value.len() - 1].to_owned()
+}
+
+fn json_tool_prefix(text: &str) -> Option<bool> {
+    let text = text.trim_start_matches(['[', ' ', '\n', '\r', '\t']);
+    if !text.is_empty() && !text.starts_with('{') {
+        return Some(false);
+    }
+    let text = text.strip_prefix('{')?.trim_start();
+    let (key, _) = json_string(text)?;
+    Some(matches!(
+        key.as_str(),
+        "tool_calls" | "tool" | "name" | "function" | "id" | "arguments"
+    ))
+}
+
+// Return a complete JSON string and the consumed byte count, respecting escaped
+// quotes and UTF-8. Incomplete strings deliberately remain pending.
+fn json_string(text: &str) -> Option<(String, usize)> {
+    if !text.starts_with('"') {
+        return None;
+    }
+    let mut escaped = false;
+    for (index, ch) in text.char_indices().skip(1) {
+        if escaped {
+            escaped = false;
+            continue;
+        }
+        if ch == '\\' {
+            escaped = true;
+        } else if ch == '"' {
+            return Some((serde_json::from_str(&text[..index + 1]).ok()?, index + 1));
+        }
+    }
+    None
+}
+
+fn json_string_prefix(text: &str) -> String {
+    if let Some((value, _)) = json_string(text) {
+        return value;
+    }
+    if !text.starts_with('"') {
+        return String::new();
+    }
+    // Retain an incomplete escape (including a surrogate pair) until it can be
+    // decoded. At most twelve trailing bytes need to be withheld.
+    let mut end = text.len();
+    for _ in 0..13 {
+        let candidate = format!("{}\"", &text[..end]);
+        if let Ok(value) = serde_json::from_str::<String>(&candidate) {
+            return value;
+        }
+        if end <= 1 {
+            break;
+        }
+        end -= 1;
+        while !text.is_char_boundary(end) {
+            end -= 1;
+        }
+    }
+    String::new()
+}
+
+// Scan values without reparsing a partial string as a complete JSON object.
+// The returned length is the complete value boundary, or None while incomplete.
+fn json_value_end(text: &str) -> Option<usize> {
+    if text.starts_with('"') {
+        return json_string(text).map(|(_, end)| end);
+    }
+    let mut depth = 0_i32;
+    let mut quoted = false;
+    let mut escape = false;
+    for (index, ch) in text.char_indices() {
+        if quoted {
+            if escape {
+                escape = false;
+            } else if ch == '\\' {
+                escape = true;
+            } else if ch == '"' {
+                quoted = false;
+            }
+            continue;
+        }
+        match ch {
+            '"' => quoted = true,
+            '{' | '[' => depth += 1,
+            '}' | ']' => {
+                depth -= 1;
+                if depth == 0 {
+                    return Some(index + 1);
+                }
+                if depth < 0 {
+                    return Some(index);
+                }
+            }
+            ',' | '\n' | '\r' | '\t' | ' ' if depth == 0 => return Some(index),
+            _ => {}
+        }
+    }
+    None
+}
+
+fn json_field<'a>(text: &'a str, wanted: &str) -> Option<&'a str> {
+    let mut rest = text.trim_start().strip_prefix('{')?.trim_start();
+    loop {
+        let (key, end) = json_string(rest)?;
+        rest = rest[end..].trim_start().strip_prefix(':')?.trim_start();
+        if key == wanted {
+            return Some(rest);
+        }
+        let end = json_value_end(rest)?;
+        rest = rest[end..].trim_start().strip_prefix(',')?.trim_start();
+    }
+}
+
+fn json_previews(text: &str) -> Vec<(String, String)> {
+    let text = text.trim_start();
+    let envelope = json_field(text, "tool_calls").unwrap_or(text);
+    let mut rest = envelope.strip_prefix('[').unwrap_or(envelope).trim_start();
+    let mut calls = Vec::new();
+    loop {
+        let function = json_field(rest, "function").unwrap_or(rest);
+        let Some(name) = json_field(rest, "tool")
+            .or_else(|| json_field(function, "name"))
+            .and_then(json_string)
+            .map(|(name, _)| name)
+        else {
+            break;
+        };
+        let arguments = json_field(function, "arguments")
+            .map(|raw| {
+                if raw.starts_with('"') {
+                    json_string_prefix(raw)
+                } else {
+                    raw[..json_value_end(raw).unwrap_or(raw.len())].to_owned()
+                }
+            })
+            .unwrap_or_default();
+        calls.push((name, arguments));
+        let Some(end) = json_value_end(rest) else {
+            break;
+        };
+        let Some(next) = rest[end..].trim_start().strip_prefix(',') else {
+            break;
+        };
+        rest = next.trim_start();
+    }
+    calls
+}
+
+fn qwen_previews(text: &str, tools: &[ToolSpec]) -> Vec<(String, String)> {
+    let mut rest = text.trim_start();
+    let mut calls = Vec::new();
+    while let Some(body) = rest.strip_prefix("<tool_call>") {
+        let Some(body) = body.trim_start().strip_prefix("<function=") else {
+            break;
+        };
+        let Some(end) = body.find('>') else {
+            break;
+        };
+        let name = body[..end].trim().to_owned();
+        let tool = tools.iter().find(|tool| tool.name == name);
+        let mut remaining = body[end + 1..].trim_start();
+        let mut arguments = String::from("{");
+        let mut first = true;
+        while let Some(parameter) = remaining.strip_prefix("<parameter=") {
+            let Some(end) = parameter.find('>') else {
+                break;
+            };
+            let key = parameter[..end].trim();
+            let raw = &parameter[end + 1..];
+            if !first {
+                arguments.push(',');
+            }
+            arguments.push_str(&serde_json::to_string(key).unwrap());
+            arguments.push(':');
+            if let Some(end) = raw.find("</parameter>") {
+                arguments.push_str(
+                    &provider_qwen_xml_parameter_value(tool, key, &raw[..end]).to_string(),
+                );
+                remaining = raw[end + "</parameter>".len()..].trim_start();
+                first = false;
+            } else {
+                let schema = tool
+                    .and_then(|tool| tool.parameters.get("properties"))
+                    .and_then(|p| p.get(key));
+                if schema
+                    .and_then(|schema| schema.get("type"))
+                    .and_then(Value::as_str)
+                    == Some("string")
+                {
+                    let end = raw.len() - suffix_prefix_len(raw, "</parameter>");
+                    let raw = &raw[..end];
+                    let raw = raw
+                        .strip_prefix("\r\n")
+                        .or_else(|| raw.strip_prefix('\n'))
+                        .unwrap_or(raw);
+                    // A native framing newline may still be the final newline.
+                    let raw = raw
+                        .strip_suffix("\r\n")
+                        .or_else(|| raw.strip_suffix('\n'))
+                        .or_else(|| raw.strip_suffix('\r'))
+                        .unwrap_or(raw);
+                    arguments.push('"');
+                    arguments.push_str(&escaped(raw));
+                }
+                break;
+            }
+        }
+        let complete = remaining
+            .strip_prefix("</function>")
+            .map(str::trim_start)
+            .and_then(|remaining| remaining.strip_prefix("</tool_call>"));
+        if complete.is_some() {
+            arguments.push('}');
+        }
+        calls.push((name, arguments));
+        let Some(next) = complete else {
+            break;
+        };
+        rest = next.trim_start();
+    }
+    calls
+}
+
+fn gemma_previews(text: &str) -> Vec<(String, String)> {
+    let mut rest = text.trim_start();
+    let mut calls = Vec::new();
+    while let Some(body) = rest.strip_prefix("<|tool_call>call:") {
+        let Some(start) = body.find('{') else {
+            break;
+        };
+        let name = body[..start].trim().to_owned();
+        let end = body.find("<tool_call|>");
+        let raw = &body
+            [start..end.unwrap_or_else(|| body.len() - suffix_prefix_len(body, "<tool_call|>"))];
+        calls.push((name, gemma_json_prefix(raw)));
+        let Some(end) = end else {
+            break;
+        };
+        rest = body[end + "<tool_call|>".len()..].trim_start();
+    }
+    calls
+}
+
+fn gemma_json_prefix(mut rest: &str) -> String {
+    let mut out = String::new();
+    let mut key = false;
+    let mut objects = Vec::new();
+    while !rest.is_empty() {
+        if let Some(raw) = rest.strip_prefix("<|\"|>") {
+            out.push('"');
+            if let Some(end) = raw.find("<|\"|>") {
+                out.push_str(&escaped(&raw[..end]));
+                out.push('"');
+                rest = &raw[end + 5..];
+            } else {
+                let end = raw.len() - suffix_prefix_len(raw, "<|\"|>");
+                out.push_str(&escaped(&raw[..end]));
+                break;
+            }
+            key = false;
+            continue;
+        }
+        if "<|\"|>".starts_with(rest) {
+            break;
+        }
+        let ch = rest.chars().next().unwrap();
+        if ch == '"' {
+            if let Some((_, end)) = json_string(rest) {
+                out.push_str(&rest[..end]);
+                rest = &rest[end..];
+                key = false;
+                continue;
+            }
+            out.push_str(rest);
+            break;
+        }
+        if key && !ch.is_whitespace() && ch != '}' && ch != '"' {
+            let Some(end) = rest.find(':') else {
+                break;
+            };
+            out.push_str(&serde_json::to_string(rest[..end].trim()).unwrap());
+            out.push(':');
+            rest = &rest[end + 1..];
+            key = false;
+            continue;
+        }
+        out.push(ch);
+        rest = &rest[ch.len_utf8()..];
+        match ch {
+            '{' => {
+                objects.push(true);
+                key = true;
+            }
+            '[' => {
+                objects.push(false);
+                key = false;
+            }
+            '}' | ']' => {
+                objects.pop();
+                key = false;
+            }
+            ',' => key = objects.last() == Some(&true),
+            ':' => key = false,
+            _ => {}
+        }
+    }
+    out
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::{provider_engine_tool_call_outputs, validate_provider_engine_tool_call_outputs};
+
+    fn tools() -> Vec<ToolSpec> {
+        vec![ToolSpec::new(
+            "write",
+            json!({"type":"object","properties":{
+            "path":{"type":"string"},"content":{"type":"string"},"data":{"type":"array"},
+            "count":{"type":["string","integer"]}},"additionalProperties":false}),
+        )]
+    }
+
+    fn check(strategy: ProviderEngineToolStrategy, raw: &str) {
+        let tools = tools();
+        let expected = provider_engine_tool_call_outputs(raw, strategy, &tools).unwrap();
+        validate_provider_engine_tool_call_outputs(&expected, &tools).unwrap();
+        // Every UTF-8 split, and one character per token, must agree with the
+        // existing final parser. This catches split markers and escape sequences.
+        for split in raw
+            .char_indices()
+            .map(|(index, _)| index)
+            .chain([raw.len()])
+        {
+            let mut stream = OutputStream::new(strategy, tools.clone());
+            let mut calls: Vec<(String, String)> = Vec::new();
+            for delta in [stream.push(&raw[..split]), stream.push(&raw[split..])] {
+                collect(delta, &mut calls);
+            }
+            compare(&calls, &expected);
+        }
+        let mut stream = OutputStream::new(strategy, tools);
+        let mut calls = Vec::new();
+        let mut first_arguments = None;
+        for (index, ch) in raw.char_indices() {
+            let delta = stream.push(&ch.to_string());
+            if delta.tools.iter().any(|tool| {
+                tool["arguments"]
+                    .as_str()
+                    .is_some_and(|args| !args.is_empty() && args != "{")
+            }) {
+                first_arguments.get_or_insert(index);
+            }
+            collect(delta, &mut calls);
+        }
+        assert!(
+            first_arguments.unwrap() < raw.len() - 5,
+            "arguments must precede generation completion"
+        );
+        compare(&calls, &expected);
+    }
+
+    fn collect(delta: Delta, calls: &mut Vec<(String, String)>) {
+        for tool in delta.tools {
+            let index = tool["index"].as_u64().unwrap() as usize;
+            if index == calls.len() {
+                calls.push((tool["name"].as_str().unwrap().to_owned(), String::new()));
+            }
+            calls[index].1.push_str(tool["arguments"].as_str().unwrap());
+        }
+    }
+
+    fn compare(calls: &[(String, String)], expected: &[Value]) {
+        assert_eq!(calls.len(), expected.len());
+        for ((name, args), expected) in calls.iter().zip(expected) {
+            assert_eq!(name, expected["name"].as_str().unwrap());
+            assert_eq!(
+                serde_json::from_str::<Value>(args).unwrap_or_else(|err| panic!("{err}: {args}")),
+                serde_json::from_str::<Value>(expected["arguments"].as_str().unwrap()).unwrap()
+            );
+        }
+    }
+
+    #[test]
+    fn all_tool_formats_stream_arguments_before_generation_finishes() {
+        check(
+            ProviderEngineToolStrategy::QwenFunctionXml,
+            "<tool_call>\n<function=write>\n<parameter=path>\nindex.html\n</parameter>\n<parameter=content>\n  <div>é🦀 \\\"hi\\\"</div>\n\n</parameter>\n<parameter=count>\n12\n</parameter>\n</function>\n</tool_call>",
+        );
+        check(
+            ProviderEngineToolStrategy::MayhemJson,
+            r#"{"tool_calls":[{"tool":"write","arguments":{"path":"index.html","content":"é \"quoted\" \ud83e\udd80","data":[1,2]}}]}"#,
+        );
+        check(
+            ProviderEngineToolStrategy::OpenAiToolCalls,
+            r#"{"tool_calls":[{"id":"native","function":{"name":"write","arguments":"{\"path\":\"index.html\",\"content\":\"hello world\"}"}},{"function":{"name":"write","arguments":{"path":"style.css"}}}]}"#,
+        );
+        check(
+            ProviderEngineToolStrategy::GemmaFunctionCall,
+            "<|tool_call>call:write{path:<|\"|>index.html<|\"|>,content:<|\"|>é🦀 \\\"quoted\\\"<|\"|>,data:[1,2,{x:true}]}<tool_call|>",
+        );
+    }
+
+    #[test]
+    fn advertising_tools_does_not_buffer_plain_text_or_ordinary_json() {
+        for strategy in [
+            ProviderEngineToolStrategy::QwenFunctionXml,
+            ProviderEngineToolStrategy::GemmaFunctionCall,
+            ProviderEngineToolStrategy::MayhemJson,
+            ProviderEngineToolStrategy::OpenAiToolCalls,
+        ] {
+            for text in [
+                "Hello, this is already available.",
+                "{\"answer\":42,\"more\":true}",
+                "[1,2,3]",
+            ] {
+                let mut stream = OutputStream::new(strategy, tools());
+                let first = stream.push(&text[..text.len() - 2]);
+                assert!(!first.text.is_empty(), "{strategy:?}: {text}");
+                let mut output = first.text;
+                output.push_str(&stream.push(&text[text.len() - 2..]).text);
+                output.push_str(&stream.finish_text(false));
+                assert_eq!(output, text);
+            }
+        }
+    }
+}

--- a/crates/mayhem-cli/src/provider_output_stream.rs
+++ b/crates/mayhem-cli/src/provider_output_stream.rs
@@ -466,6 +466,56 @@ mod tests {
     use super::*;
     use crate::{provider_engine_tool_call_outputs, validate_provider_engine_tool_call_outputs};
 
+    #[test]
+    fn constrained_json_streams_as_tools_or_answer_without_false_reasoning() {
+        use crate::{
+            ProviderReasoningOutputFilter, ProviderReasoningOutputMode,
+            provider_constrained_reasoning_output_mode,
+        };
+        let mode = provider_constrained_reasoning_output_mode(
+            ProviderReasoningOutputMode::StripPrefilled,
+            true,
+        );
+        let raw = r#"{"tool":"write","arguments":{"path":"demo.html","content":"hello world"}}"#;
+        let mut reasoning = ProviderReasoningOutputFilter::new(mode);
+        let mut output = OutputStream::new(ProviderEngineToolStrategy::MayhemJson, tools());
+        let mut calls = Vec::new();
+        let mut saw_arguments_before_end = false;
+        for (index, ch) in raw.char_indices() {
+            let filtered = reasoning.push_split(&ch.to_string());
+            assert!(
+                filtered.hidden.is_empty(),
+                "constrained JSON was classified as thinking"
+            );
+            let delta = output.push(&filtered.visible);
+            if !delta.tools.is_empty() && index < raw.len() - 10 {
+                saw_arguments_before_end = true;
+            }
+            collect(delta, &mut calls);
+        }
+        assert!(saw_arguments_before_end);
+        compare(
+            &calls,
+            &provider_engine_tool_call_outputs(
+                raw,
+                ProviderEngineToolStrategy::MayhemJson,
+                &tools(),
+            )
+            .unwrap(),
+        );
+        let mut reasoning = ProviderReasoningOutputFilter::new(mode);
+        let first = reasoning.push_split("{\"answer\":");
+        assert_eq!(first.visible, "{\"answer\":");
+        assert!(first.hidden.is_empty());
+        assert_eq!(
+            provider_constrained_reasoning_output_mode(
+                ProviderReasoningOutputMode::StripPrefilled,
+                false
+            ),
+            ProviderReasoningOutputMode::StripPrefilled
+        );
+    }
+
     fn tools() -> Vec<ToolSpec> {
         vec![ToolSpec::new(
             "write",

--- a/crates/mayhem-gateway/src/openai.rs
+++ b/crates/mayhem-gateway/src/openai.rs
@@ -133,6 +133,7 @@ type SharedState = Arc<GatewayState>;
 #[cfg(test)]
 mod durable_streaming_tests;
 mod response_stream;
+mod incremental_output;
 
 mod github_update;
 use github_update::{
@@ -3902,6 +3903,7 @@ fn spawn_pending_gateway_job_reconciliation(state: &GatewayState) -> Result<(), 
 
 fn chat_job_result(output: &ChatOutput) -> Value {
     json!({
+        "reasoning_content": output.reasoning_content,
         "kind": "chat",
         "content": output.content,
         "tool_calls": output.tool_calls.iter().map(tool_call_value).collect::<Vec<_>>(),
@@ -4183,6 +4185,7 @@ pub struct ScBridgeGatewaySessionBackend {
 
 #[derive(Clone, Debug)]
 pub struct ChatOutput {
+    pub reasoning_content: String,
     pub content: Option<String>,
     pub tool_calls: Vec<ToolCallOutput>,
     pub artifacts: Vec<GatewayArtifactOutput>,
@@ -18819,7 +18822,8 @@ async fn collect_direct_session_output(
     })?;
     Ok(DirectSessionCollected {
         output: ChatOutput {
-            content: tool_calls.is_empty().then_some(content),
+            reasoning_content: incremental_output::reasoning_text(&reasoning_evidence),
+            content: (!content.is_empty() || tool_calls.is_empty()).then_some(content),
             tool_calls,
             artifacts,
             finish_reason,
@@ -19662,6 +19666,7 @@ fn interrupted_direct_session_partial(
     });
     Some(GatewaySessionPartial {
         output: ChatOutput {
+            reasoning_content: String::new(),
             content: tool_calls.is_empty().then_some(content.to_owned()),
             tool_calls,
             artifacts: Vec::new(),
@@ -19747,6 +19752,7 @@ fn client_disconnect_direct_session_error(
         err.message,
         GatewaySessionInterrupted {
             output: ChatOutput {
+                reasoning_content: String::new(),
                 content: tool_calls.is_empty().then_some(content.to_owned()),
                 tool_calls,
                 artifacts: Vec::new(),
@@ -19784,6 +19790,7 @@ fn direct_session_checkpoint_partial(
             });
     GatewaySessionPartial {
         output: ChatOutput {
+            reasoning_content: String::new(),
             content: tool_calls.is_empty().then_some(content.to_owned()),
             tool_calls,
             artifacts: Vec::new(),
@@ -20769,6 +20776,11 @@ async fn cancel_and_settle_direct_session(
                     &invocation.session_id,
                     enclave_pubkey,
                 )?;
+                // A checkpoint sent before the close may still be queued. It
+                // was not acknowledged by the interrupted collector, so do not
+                // advance settlement to it. The provider cancels at its previous
+                // signed high water after its bounded ACK drain.
+                if !receipt.body.final_receipt { continue; }
                 let receipt_ack = record_cancelled_direct_session_receipt(
                     model,
                     invocation,
@@ -24703,127 +24715,18 @@ where
 
 async fn finish_live_direct_chat_after_client_disconnect(
     session: &mut LiveDirectChatSession,
-    mut err: GatewaySessionError,
+    err: GatewaySessionError,
 ) -> Result<(), GatewaySessionError> {
-    // Tool-bearing requests can be accepted and generate for a long time
-    // before publishing their first delta. Closing the transport here loses
-    // the provider's final cancellation receipt and strands the full voucher
-    // on the ledger. Use the same settlement handshake as non-streaming work.
-    if err.partial.is_none() && err.interrupted.is_none() {
-        return cancel_and_settle_direct_session(
-            &mut session.bridge,
-            &session.invocation,
-            &session.transport_peer,
-            &session.provider,
-            &session.model,
-            &session.enclave_pubkey,
-            blake3_hex(chat_prompt_text(&session.request).as_bytes()),
-            ReceiptUsage::default(),
-            1,
-        )
-        .await;
-    }
-    if let Some(partial) = err.partial.take() {
-        session
-            .state
-            .record_partial_provider_receipt(
-                &session.model,
-                &session.request,
-                &session.invocation,
-                &partial,
-            )
-            .map_err(|err| GatewaySessionError::new(err.message))?;
-        let _ = close_direct_session_channel(
-            &mut session.bridge,
-            &session.transport_peer,
-            &session.invocation.session_id,
-            "client_disconnect",
-        )
-        .await;
-        return Ok(());
-    }
-    let _ = close_direct_session_channel(
-        &mut session.bridge,
-        &session.transport_peer,
-        &session.invocation.session_id,
-        "client_disconnect",
-    )
-    .await;
-    if let Some(interrupted) = err.interrupted.take() {
-        if let Some(partial) =
-            wait_for_client_disconnect_provider_receipt(session, *interrupted).await?
-        {
-            let stored = session
-                .state
-                .record_partial_provider_receipt(
-                    &session.model,
-                    &session.request,
-                    &session.invocation,
-                    &partial,
-                )
-                .map_err(|err| GatewaySessionError::new(err.message))?;
-            let _ = send_receipt_ack_and_queue_settlement(
-                &mut session.bridge,
-                &session.transport_peer,
-                &session.invocation,
-                &partial.provider_receipt,
-                &stored.receipt_ack,
-                Some("client_disconnect"),
-                "sending client-disconnect s.receipt_ack",
-            )
-            .await;
-        }
-    }
-    Ok(())
-}
-
-async fn wait_for_client_disconnect_provider_receipt(
-    session: &mut LiveDirectChatSession,
-    interrupted: GatewaySessionInterrupted,
-) -> Result<Option<GatewaySessionPartial>, GatewaySessionError> {
-    let deadline = Instant::now() + Duration::from_secs(5);
-    loop {
-        let remaining = deadline.saturating_duration_since(Instant::now());
-        if remaining.is_zero() {
-            return Ok(None);
-        }
-        let frame = match next_session_frame(
-            &mut session.bridge,
-            &session.invocation.session_id,
-            &session.transport_peer,
-            remaining,
-            &["s.receipt", "s.close", "s.error"],
-        )
-        .await
-        {
-            Ok(frame) => frame,
-            Err(err) if err.message.starts_with("timed out waiting") => return Ok(None),
-            Err(err) => return Err(err),
-        };
-        match frame.get("t").and_then(Value::as_str) {
-            Some("s.receipt") => {
-                let receipt = provider_signed_receipt_from_frame(
-                    &frame,
-                    &session.invocation.session_id,
-                    &session.enclave_pubkey,
-                )?;
-                if receipt.body.final_receipt {
-                    continue;
-                }
-                return Ok(Some(GatewaySessionPartial {
-                    output: interrupted.output,
-                    provider_receipt: receipt,
-                    token_ids: interrupted.token_ids,
-                    quality: interrupted.quality,
-                    reason: interrupted.reason,
-                    redispatch_mode: RedispatchMode::FullMessageHistoryClientSide,
-                }));
-            }
-            Some("s.close") => return Ok(None),
-            Some("s.error") => return Ok(None),
-            _ => {}
-        }
-    }
+    // Stop generation but keep the direct channel alive until a final signed
+    // receipt closes the voucher. Only acknowledged checkpoints are chargeable.
+    let (usage, seq) = err.partial.as_ref().map(|partial|
+        (partial.provider_receipt.body.usage.clone(), partial.provider_receipt.body.seq.saturating_add(1)))
+        .unwrap_or_else(|| (ReceiptUsage::default(), 1));
+    cancel_and_settle_direct_session(
+        &mut session.bridge, &session.invocation, &session.transport_peer,
+        &session.provider, &session.model, &session.enclave_pubkey,
+        blake3_hex(chat_prompt_text(&session.request).as_bytes()), usage, seq,
+    ).await
 }
 
 async fn recover_live_direct_chat_after_retryable(
@@ -24981,6 +24884,8 @@ async fn run_live_direct_chat_sse_inner(
 
     let mut content = String::new();
     let mut reasoning_evidence = String::new();
+    let mut reasoning_stream = incremental_output::ReasoningStream::default();
+    let mut tool_stream = incremental_output::ToolStream::default();
     let mut tool_calls = Vec::new();
     let mut finish_reason = None;
     let mut claimed_usage = None;
@@ -25197,6 +25102,17 @@ async fn run_live_direct_chat_sse_inner(
                         ));
                     }
                 }
+                let reasoning_delta = reasoning_stream.push(session_delta_reasoning_evidence(&frame)?);
+                let tool_deltas = tool_stream.push(&frame, &session.request, max_text_bytes)?;
+                let mut public_delta = json!({});
+                if !reasoning_delta.is_empty() { public_delta["reasoning_content"] = json!(reasoning_delta); }
+                if !tool_deltas.is_empty() { public_delta["tool_calls"] = json!(tool_deltas); }
+                if public_delta.as_object().is_some_and(|delta| !delta.is_empty()) && !send_sse_value(tx,
+                    chat_chunk(&session.id, session.created, &session.model.id, public_delta, None, None)).await {
+                    return Err(client_disconnect_direct_session_error(&session.request, &content,
+                        &reasoning_evidence, tool_calls.clone(), latest_checkpoint_receipt.as_ref(),
+                        &token_ids, &watchdog, now));
+                }
                 if let Some(receipt) = pending_checkpoint_receipt.take() {
                     if let Some(ack_frame) = maybe_ack_direct_session_checkpoint_receipt(
                         &mut session.bridge,
@@ -25231,7 +25147,7 @@ async fn run_live_direct_chat_sse_inner(
                                 &session.id,
                                 session.created,
                                 &session.model.id,
-                                json!({ "tool_calls": tool_call_delta_values(&next_tool_calls) }),
+                                json!({ "tool_calls": tool_stream.finish(&next_tool_calls)? }),
                                 None,
                                 None,
                             ),
@@ -25254,6 +25170,14 @@ async fn run_live_direct_chat_sse_inner(
                 }
                 collect_artifact_from_session_delta(&frame, &mut artifact_builders)?;
                 if let Some(fin) = frame.get("fin").and_then(Value::as_str) {
+                    if tool_calls.is_empty() { tool_stream.finish(&[])?; }
+                    let tail = reasoning_stream.finish();
+                    if !tail.is_empty() && !send_sse_value(tx, chat_chunk(&session.id, session.created,
+                        &session.model.id, json!({"reasoning_content":tail}), None, None)).await {
+                        return Err(client_disconnect_direct_session_error(&session.request, &content,
+                            &reasoning_evidence, tool_calls.clone(), latest_checkpoint_receipt.as_ref(),
+                            &token_ids, &watchdog, now));
+                    }
                     finish_reason = Some(fin.to_owned());
                     claimed_usage = usage_from_session_delta(&frame);
                     claimed_usage_attribution = usage_attribution_from_session_delta(&frame)?;
@@ -25473,7 +25397,8 @@ async fn run_live_direct_chat_sse_inner(
         ))
     })?;
     let output = ChatOutput {
-        content: tool_calls.is_empty().then_some(content),
+        reasoning_content: incremental_output::reasoning_text(&reasoning_evidence),
+        content: (!content.is_empty() || tool_calls.is_empty()).then_some(content),
         tool_calls,
         artifacts,
         finish_reason,
@@ -28811,6 +28736,11 @@ fn responses_value_from_chat(response: Value) -> Result<Value, ApiError> {
         .ok_or_else(|| ApiError::bad_gateway("chat provider returned no choices", Some("model")))?;
     let message = choice.get("message").cloned().unwrap_or_else(|| json!({}));
     let mut output = Vec::new();
+    if let Some(text) = message.get("reasoning_content").and_then(Value::as_str).filter(|s| !s.is_empty()) {
+        output.push(json!({"id":make_id("rs"),"type":"reasoning","status":"completed",
+            "summary":[],"content":[{"type":"reasoning_text","text":text}]}));
+    }
+
     if let Some(text) = message.get("content").and_then(Value::as_str) {
         if !text.is_empty() {
             output.push(json!({
@@ -35394,6 +35324,7 @@ fn dev_chat_output(model: &GatewayModel, request: &ChatCompletionRequest) -> Cha
         .join("\n");
     let output = if let Some(tool_result) = last_tool_result(&request.messages) {
         ChatOutput {
+            reasoning_content: String::new(),
             content: Some(format!("Tool result received: {tool_result}")),
             tool_calls: Vec::new(),
             artifacts: Vec::new(),
@@ -35407,6 +35338,7 @@ fn dev_chat_output(model: &GatewayModel, request: &ChatCompletionRequest) -> Cha
             name,
         };
         ChatOutput {
+            reasoning_content: String::new(),
             content: None,
             tool_calls: vec![tool_call],
             artifacts: Vec::new(),
@@ -35442,6 +35374,7 @@ fn dev_chat_output(model: &GatewayModel, request: &ChatCompletionRequest) -> Cha
             )
         };
         ChatOutput {
+            reasoning_content: String::new(),
             usage: usage_for(&prompt_text, &content),
             content: Some(content),
             tool_calls: Vec::new(),
@@ -35460,10 +35393,10 @@ fn chat_response_value(
     receipt: Option<&StoredReceipt>,
     mayhem_meta: ResponseMayhemMeta<'_>,
 ) -> Value {
-    let message = if !output.tool_calls.is_empty() {
+    let mut message = if !output.tool_calls.is_empty() {
         json!({
             "role": "assistant",
-            "content": null,
+            "content": output.content,
             "tool_calls": output.tool_calls.iter().map(tool_call_value).collect::<Vec<_>>(),
         })
     } else {
@@ -35472,6 +35405,7 @@ fn chat_response_value(
             "content": output.content.clone().unwrap_or_default(),
         })
     };
+    if !output.reasoning_content.is_empty() { message["reasoning_content"] = json!(output.reasoning_content); }
     json!({
         "id": id,
         "object": "chat.completion",
@@ -35520,6 +35454,9 @@ fn chat_stream_chunks(
         None,
         None,
     )];
+    for part in stream_parts(&output.reasoning_content) {
+        if !part.is_empty() { chunks.push(chat_chunk(id, created, model, json!({"reasoning_content":part}), None, None)); }
+    }
     if !output.tool_calls.is_empty() {
         chunks.push(chat_chunk(
             id,
@@ -41015,6 +40952,7 @@ mod tests {
         assert_eq!(checkpointed_stored.receipt.body.seq, 3);
 
         let cached_output = ChatOutput {
+            reasoning_content: String::new(),
             usage: Usage {
                 prompt_tokens: 1_000,
                 completion_tokens: 0,
@@ -43275,6 +43213,7 @@ mod tests {
                     let completion_tokens = visible_output_unit_count("hello ", &[]);
                     let prompt_tokens = rough_tokens(&chat_prompt_text(request));
                     let output = ChatOutput {
+                        reasoning_content: String::new(),
                         content: Some("hello ".to_owned()),
                         tool_calls: Vec::new(),
                         artifacts: Vec::new(),
@@ -43313,6 +43252,7 @@ mod tests {
                 let completion_tokens = visible_output_unit_count("world", &[]);
                 let prompt_tokens = rough_tokens(&chat_prompt_text(request));
                 let output = ChatOutput {
+                    reasoning_content: String::new(),
                     content: Some("world".to_owned()),
                     tool_calls: Vec::new(),
                     artifacts: Vec::new(),
@@ -43370,6 +43310,7 @@ mod tests {
                 let prompt_tokens = rough_tokens(&chat_prompt_text(request));
                 let completion_tokens = visible_output_unit_count("", &tool_calls);
                 let output = ChatOutput {
+                    reasoning_content: String::new(),
                     content: None,
                     tool_calls,
                     artifacts: Vec::new(),
@@ -43428,6 +43369,7 @@ mod tests {
                 };
                 if attempt == 1 {
                     let output = ChatOutput {
+                        reasoning_content: String::new(),
                         content: Some("checkpoint ".to_owned()),
                         tool_calls: Vec::new(),
                         artifacts: Vec::new(),
@@ -43456,6 +43398,7 @@ mod tests {
 
                 let prompt_tokens = rough_tokens(&chat_prompt_text(request));
                 let output = ChatOutput {
+                    reasoning_content: String::new(),
                     content: Some("continued".to_owned()),
                     tool_calls: Vec::new(),
                     artifacts: Vec::new(),
@@ -43510,6 +43453,7 @@ mod tests {
                 };
                 Ok(GatewaySessionResult {
                     output: ChatOutput {
+                        reasoning_content: String::new(),
                         content: Some(content.to_owned()),
                         tool_calls: Vec::new(),
                         artifacts: Vec::new(),
@@ -43573,6 +43517,7 @@ mod tests {
                 let prompt_tokens = rough_tokens(&chat_prompt_text(request));
                 Ok(GatewaySessionResult {
                     output: ChatOutput {
+                        reasoning_content: String::new(),
                         content: Some("recovered".to_owned()),
                         tool_calls: Vec::new(),
                         artifacts: Vec::new(),
@@ -43749,6 +43694,7 @@ mod tests {
                 let prompt_tokens = rough_tokens(&chat_prompt_text(request));
                 Ok(GatewaySessionResult {
                     output: ChatOutput {
+                        reasoning_content: String::new(),
                         content: Some("recovered after close".to_owned()),
                         tool_calls: Vec::new(),
                         artifacts: Vec::new(),
@@ -44043,6 +43989,7 @@ mod tests {
                 let prompt_tokens = rough_tokens(&chat_prompt_text(request));
                 Ok(GatewaySessionResult {
                     output: ChatOutput {
+                        reasoning_content: String::new(),
                         content: Some("ok".to_owned()),
                         tool_calls: Vec::new(),
                         artifacts: Vec::new(),
@@ -51035,6 +50982,7 @@ mod tests {
 
     pub(super) fn test_chat_output() -> ChatOutput {
         ChatOutput {
+            reasoning_content: String::new(),
             content: Some("receipt ok".to_owned()),
             tool_calls: Vec::new(),
             artifacts: Vec::new(),

--- a/crates/mayhem-gateway/src/openai.rs
+++ b/crates/mayhem-gateway/src/openai.rs
@@ -24968,6 +24968,21 @@ async fn run_live_direct_chat_sse_inner(
         };
         let frame = match frame_result {
             Ok(frame) => frame,
+            Err(err) if is_client_disconnect_error(&err) => {
+                // Explicit job cancellation races the HTTP socket closing.
+                // Preserve the same acknowledged high water on either path;
+                // a bare cancellation error would expect a zero-usage receipt.
+                return Err(client_disconnect_direct_session_error(
+                    &session.request,
+                    &content,
+                    &reasoning_evidence,
+                    tool_calls.clone(),
+                    latest_checkpoint_receipt.as_ref(),
+                    &token_ids,
+                    &watchdog,
+                    now_millis_u64(),
+                ));
+            }
             Err(err) if err.message.starts_with("timed out waiting") => {
                 let now = now_millis_u64();
                 if let Some(ack_frame) = latest_checkpoint_ack_frame.clone() {

--- a/crates/mayhem-gateway/src/openai/incremental_output.rs
+++ b/crates/mayhem-gateway/src/openai/incremental_output.rs
@@ -61,6 +61,7 @@ pub(super) fn reasoning_text(evidence: &str) -> String {
 #[derive(Default)]
 pub(super) struct ToolStream {
     calls: Vec<ToolCallOutput>,
+    public_lengths: Vec<usize>,
     bytes: usize,
     finalized: bool,
 }
@@ -132,6 +133,7 @@ impl ToolStream {
                     name: name.to_owned(),
                     arguments: String::new(),
                 });
+                self.public_lengths.push(0);
             } else if delta.get("id").is_some() || delta.get("name").is_some() {
                 return Err(error("tool delta attempted to replace call identity"));
             }
@@ -140,6 +142,12 @@ impl ToolStream {
                 return Err(error("streamed tool arguments exceeded session text limit"));
             }
             self.calls[index].arguments.push_str(arguments);
+            // Some clients execute as soon as input is valid JSON. Retain its
+            // final delimiter until the provider's final schema check succeeds.
+            let arguments = &self.calls[index].arguments;
+            let end = provisional_argument_end(arguments);
+            public["function"]["arguments"] = json!(&arguments[self.public_lengths[index]..end]);
+            self.public_lengths[index] = end;
             output.push(public);
         }
         Ok(output)
@@ -155,7 +163,8 @@ impl ToolStream {
                 if prior.id != call.id || prior.name != call.name {
                     return Err(error("final tool identity differs from streamed call"));
                 }
-                if let Some(tail) = call.arguments.strip_prefix(&prior.arguments) {
+                if call.arguments.starts_with(&prior.arguments) {
+                    let tail = &call.arguments[self.public_lengths[index]..];
                     if !tail.is_empty() {
                         deltas.push(json!({"index":index,"function":{"arguments":tail}}));
                     }
@@ -167,6 +176,10 @@ impl ToolStream {
                     if prior != final_args {
                         return Err(error("final tool arguments differ from streamed call"));
                     }
+                    let tail = &self.calls[index].arguments[self.public_lengths[index]..];
+                    if !tail.is_empty() {
+                        deltas.push(json!({"index":index,"function":{"arguments":tail}}));
+                    }
                 }
             } else {
                 deltas.push(json!({"index":index,"id":call.id,"type":"function","function":{"name":call.name,"arguments":call.arguments}}));
@@ -174,6 +187,24 @@ impl ToolStream {
         }
         self.finalized = true;
         Ok(deltas)
+    }
+}
+
+fn provisional_argument_end(arguments: &str) -> usize {
+    if !arguments.trim_start().starts_with(['{', '[']) {
+        // A scalar can be valid before it is complete (e.g. 1 then 12).
+        return 0;
+    }
+    let mut values = serde_json::Deserializer::from_str(arguments).into_iter::<Value>();
+    if matches!(values.next(), Some(Ok(_))) {
+        arguments[..values.byte_offset()]
+            .trim_end()
+            .char_indices()
+            .last()
+            .map(|(index, _)| index)
+            .unwrap_or(0)
+    } else {
+        arguments.len()
     }
 }
 
@@ -237,7 +268,16 @@ mod tests {
             name: "write".into(),
             arguments: "{\"content\":\"hello world\"}".into(),
         };
-        assert!(stream.finish(&[call.clone()]).unwrap().is_empty());
+        let partial = format!(
+            "{}{}",
+            first[0]["function"]["arguments"].as_str().unwrap(),
+            second[0]["function"]["arguments"].as_str().unwrap()
+        );
+        assert!(serde_json::from_str::<Value>(&partial).is_err());
+        assert_eq!(
+            stream.finish(&[call.clone()]).unwrap()[0]["function"]["arguments"],
+            "}"
+        );
         let mut wrong = call;
         wrong.arguments = "{}".into();
         assert!(stream.finish(&[wrong]).is_err());
@@ -267,5 +307,29 @@ mod tests {
             )
             .unwrap();
         assert!(stream.finish(&[]).is_err());
+    }
+
+    #[test]
+    fn complete_input_waits_for_validation_even_with_trailing_whitespace() {
+        let mut stream = ToolStream::default();
+        let first = stream.push(&json!({"tool_calls_delta":[{"index":0,"id":"x","name":"write","arguments":"{ \"content\" : \"é🦀\" }  "}]}), &request(), 1024).unwrap();
+        let partial = first[0]["function"]["arguments"].as_str().unwrap();
+        assert!(serde_json::from_str::<Value>(partial).is_err());
+        let mut call = ToolCallOutput {
+            id: "x".into(),
+            name: "write".into(),
+            arguments: "{}".into(),
+        };
+        assert!(stream.finish(&[call.clone()]).is_err());
+        call.arguments = r#"{"content":"é🦀"}"#.into();
+        let final_delta = stream.finish(&[call]).unwrap();
+        let complete = format!(
+            "{partial}{}",
+            final_delta[0]["function"]["arguments"].as_str().unwrap()
+        );
+        assert_eq!(
+            serde_json::from_str::<Value>(&complete).unwrap(),
+            json!({"content":"é🦀"})
+        );
     }
 }

--- a/crates/mayhem-gateway/src/openai/incremental_output.rs
+++ b/crates/mayhem-gateway/src/openai/incremental_output.rs
@@ -1,0 +1,271 @@
+use super::{ChatCompletionRequest, GatewaySessionError, ToolCallOutput, Value, json};
+
+/// Presentation only: receipt accounting continues to use the exact evidence
+/// bytes, including native delimiters, and never charges this second view twice.
+#[derive(Default)]
+pub(super) struct ReasoningStream {
+    pending: String,
+    ended: bool,
+}
+
+impl ReasoningStream {
+    pub fn push(&mut self, text: &str) -> String {
+        if self.ended {
+            return String::new();
+        }
+        self.pending.push_str(text);
+        let mut out = String::new();
+        const MARKERS: [&str; 4] = ["<think>", "</think>", "<|channel>thought\n", "<channel|>"];
+        loop {
+            let found = MARKERS
+                .iter()
+                .filter_map(|marker| self.pending.find(marker).map(|index| (index, *marker)))
+                .min_by_key(|(index, _)| *index);
+            if let Some((index, marker)) = found {
+                out.push_str(&self.pending[..index]);
+                self.pending.drain(..index + marker.len());
+                if marker == "</think>" || marker == "<channel|>" {
+                    self.pending.clear();
+                    self.ended = true;
+                    break;
+                }
+            } else {
+                let retained = MARKERS
+                    .iter()
+                    .flat_map(|marker| (1..marker.len()).map(move |n| &marker[..n]))
+                    .filter(|prefix| self.pending.ends_with(prefix))
+                    .map(str::len)
+                    .max()
+                    .unwrap_or(0);
+                let end = self.pending.len() - retained;
+                out.push_str(&self.pending[..end]);
+                self.pending.drain(..end);
+                break;
+            }
+        }
+        out
+    }
+
+    pub fn finish(&mut self) -> String {
+        std::mem::take(&mut self.pending)
+    }
+}
+
+pub(super) fn reasoning_text(evidence: &str) -> String {
+    let mut stream = ReasoningStream::default();
+    let mut text = stream.push(evidence);
+    text.push_str(&stream.finish());
+    text
+}
+
+#[derive(Default)]
+pub(super) struct ToolStream {
+    calls: Vec<ToolCallOutput>,
+    bytes: usize,
+    finalized: bool,
+}
+
+impl ToolStream {
+    pub fn push(
+        &mut self,
+        frame: &Value,
+        request: &ChatCompletionRequest,
+        limit: usize,
+    ) -> Result<Vec<Value>, GatewaySessionError> {
+        let Some(raw) = frame.get("tool_calls_delta") else {
+            return Ok(Vec::new());
+        };
+        let deltas = raw
+            .as_array()
+            .ok_or_else(|| error("tool_calls_delta must be an array"))?;
+        if self.finalized && !deltas.is_empty() {
+            return Err(error("tool deltas followed final tool calls"));
+        }
+        let mut output = Vec::new();
+        for delta in deltas {
+            let index = delta
+                .get("index")
+                .and_then(Value::as_u64)
+                .and_then(|n| usize::try_from(n).ok())
+                .ok_or_else(|| error("tool delta missing index"))?;
+            if index > self.calls.len() {
+                return Err(error("tool delta skipped a call index"));
+            }
+            let arguments = delta
+                .get("arguments")
+                .and_then(Value::as_str)
+                .ok_or_else(|| error("tool delta missing arguments"))?;
+            let mut public = json!({"index":index,"function":{"arguments":arguments}});
+            if index == self.calls.len() {
+                if index >= 1024 || (index > 0 && request.parallel_tool_calls == Some(false)) {
+                    return Err(error("too many streamed tool calls"));
+                }
+                let id = delta
+                    .get("id")
+                    .and_then(Value::as_str)
+                    .filter(|id| !id.is_empty())
+                    .ok_or_else(|| error("first tool delta missing id"))?;
+                let name = delta
+                    .get("name")
+                    .and_then(Value::as_str)
+                    .ok_or_else(|| error("first tool delta missing name"))?;
+                if !request.tools.as_ref().into_iter().flatten().any(|tool| {
+                    tool.pointer("/function/name")
+                        .or_else(|| tool.get("name"))
+                        .and_then(Value::as_str)
+                        == Some(name)
+                }) {
+                    return Err(error("provider streamed an unadvertised tool"));
+                }
+                if self.calls.iter().any(|call| call.id == id) {
+                    return Err(error("duplicate streamed tool id"));
+                }
+                self.bytes = self
+                    .bytes
+                    .saturating_add(id.len())
+                    .saturating_add(name.len());
+                public["id"] = json!(id);
+                public["type"] = json!("function");
+                public["function"]["name"] = json!(name);
+                self.calls.push(ToolCallOutput {
+                    id: id.to_owned(),
+                    name: name.to_owned(),
+                    arguments: String::new(),
+                });
+            } else if delta.get("id").is_some() || delta.get("name").is_some() {
+                return Err(error("tool delta attempted to replace call identity"));
+            }
+            self.bytes = self.bytes.saturating_add(arguments.len());
+            if self.bytes > limit {
+                return Err(error("streamed tool arguments exceeded session text limit"));
+            }
+            self.calls[index].arguments.push_str(arguments);
+            output.push(public);
+        }
+        Ok(output)
+    }
+
+    pub fn finish(&mut self, calls: &[ToolCallOutput]) -> Result<Vec<Value>, GatewaySessionError> {
+        if self.calls.len() > calls.len() {
+            return Err(error("streamed tool call missing from final output"));
+        }
+        let mut deltas = Vec::new();
+        for (index, call) in calls.iter().enumerate() {
+            if let Some(prior) = self.calls.get(index) {
+                if prior.id != call.id || prior.name != call.name {
+                    return Err(error("final tool identity differs from streamed call"));
+                }
+                if let Some(tail) = call.arguments.strip_prefix(&prior.arguments) {
+                    if !tail.is_empty() {
+                        deltas.push(json!({"index":index,"function":{"arguments":tail}}));
+                    }
+                } else {
+                    let prior = serde_json::from_str::<Value>(&prior.arguments)
+                        .map_err(|_| error("streamed tool arguments are incomplete"))?;
+                    let final_args = serde_json::from_str::<Value>(&call.arguments)
+                        .map_err(|_| error("final tool arguments are invalid"))?;
+                    if prior != final_args {
+                        return Err(error("final tool arguments differ from streamed call"));
+                    }
+                }
+            } else {
+                deltas.push(json!({"index":index,"id":call.id,"type":"function","function":{"name":call.name,"arguments":call.arguments}}));
+            }
+        }
+        self.finalized = true;
+        Ok(deltas)
+    }
+}
+
+fn error(message: &str) -> GatewaySessionError {
+    GatewaySessionError::new(message)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn reasoning_is_available_before_the_closing_marker_without_changing_evidence() {
+        for raw in [
+            "<think>Consider é🦀 step by step.</think>\n\n",
+            "Consider é🦀 step by step.</think>\n\n",
+            "<|channel>thought\nConsider é🦀 step by step.<channel|>\n",
+        ] {
+            for split in raw.char_indices().map(|(index, _)| index) {
+                let mut stream = ReasoningStream::default();
+                let first = stream.push(&raw[..split]);
+                let second = stream.push(&raw[split..]);
+                assert_eq!(
+                    format!("{first}{second}{}", stream.finish()),
+                    "Consider é🦀 step by step."
+                );
+            }
+            let mut stream = ReasoningStream::default();
+            let until = raw.find("step by").unwrap();
+            assert!(stream.push(&raw[..until]).contains("Consider"));
+            assert_eq!(reasoning_text(raw), "Consider é🦀 step by step.");
+            assert_eq!(
+                super::super::metered_output_units("", raw, &[]),
+                (raw.len() as u64).div_ceil(4)
+            );
+        }
+    }
+
+    fn request() -> ChatCompletionRequest {
+        let mut request = super::super::tests::test_chat_request("model");
+        request.tools = Some(vec![json!({"type":"function","function":{"name":"write"}})]);
+        request
+    }
+
+    #[test]
+    fn tool_arguments_stream_once_and_are_bound_to_the_final_call() {
+        let mut stream = ToolStream::default();
+        let request = request();
+        let first = stream.push(&json!({"tool_calls_delta":[{"index":0,"id":"call-x","name":"write","arguments":"{\"content\":\"hello"}]}), &request, 1024).unwrap();
+        assert_eq!(first[0]["function"]["arguments"], "{\"content\":\"hello");
+        let second = stream
+            .push(
+                &json!({"tool_calls_delta":[{"index":0,"arguments":" world\"}"}]}),
+                &request,
+                1024,
+            )
+            .unwrap();
+        assert!(second[0].get("id").is_none());
+        let call = ToolCallOutput {
+            id: "call-x".into(),
+            name: "write".into(),
+            arguments: "{\"content\":\"hello world\"}".into(),
+        };
+        assert!(stream.finish(&[call.clone()]).unwrap().is_empty());
+        let mut wrong = call;
+        wrong.arguments = "{}".into();
+        assert!(stream.finish(&[wrong]).is_err());
+    }
+
+    #[test]
+    fn tool_previews_enforce_bounds_identity_and_advertised_names() {
+        let request = request();
+        for delta in [
+            json!({"index":1,"id":"x","name":"write","arguments":"{"}),
+            json!({"index":0,"id":"x","name":"unknown","arguments":"{"}),
+            json!({"index":0,"name":"write","arguments":"{"}),
+            json!({"index":0,"id":"x","name":"write","arguments":"x".repeat(1024)}),
+        ] {
+            assert!(
+                ToolStream::default()
+                    .push(&json!({"tool_calls_delta":[delta]}), &request, 1024)
+                    .is_err()
+            );
+        }
+        let mut stream = ToolStream::default();
+        stream
+            .push(
+                &json!({"tool_calls_delta":[{"index":0,"id":"x","name":"write","arguments":"{"}]}),
+                &request,
+                1024,
+            )
+            .unwrap();
+        assert!(stream.finish(&[]).is_err());
+    }
+}

--- a/crates/mayhem-gateway/src/openai/response_stream.rs
+++ b/crates/mayhem-gateway/src/openai/response_stream.rs
@@ -1,6 +1,6 @@
 use super::{
-    json, make_id, now_secs, stream, AtomicU64, BTreeMap, Ordering, SseEventStream, StreamExt,
-    Value, VecDeque,
+    AtomicU64, BTreeMap, Ordering, SseEventStream, StreamExt, Value, VecDeque, json, make_id,
+    now_secs, stream,
 };
 
 fn response_item_id(prefix: &str) -> String {
@@ -39,6 +39,7 @@ struct ResponseStream {
     response: Value,
     output: Vec<Value>,
     text_index: Option<usize>,
+    reasoning_index: Option<usize>,
     calls: BTreeMap<u64, usize>,
     finish_reason: Option<String>,
     sequence: u64,
@@ -55,6 +56,7 @@ impl ResponseStream {
             }),
             output: Vec::new(),
             text_index: None,
+            reasoning_index: None,
             calls: BTreeMap::new(),
             finish_reason: None,
             sequence: 0,
@@ -108,6 +110,34 @@ impl ResponseStream {
                 self.finish_reason = Some(reason.to_owned());
             }
             let delta = &choice["delta"];
+            if let Some(text) = delta
+                .get("reasoning_content")
+                .and_then(Value::as_str)
+                .filter(|text| !text.is_empty())
+            {
+                let index = match self.reasoning_index {
+                    Some(index) => index,
+                    None => {
+                        let index = self.output.len();
+                        let item = json!({"id":response_item_id("rs"),"type":"reasoning","status":"in_progress","summary":[],"content":[]});
+                        events.push_back(self.event(
+                            "response.output_item.added",
+                            json!({"output_index":index,"item":item}),
+                        ));
+                        let part = json!({"type":"reasoning_text","text":""});
+                        events.push_back(self.event("response.content_part.added", json!({"output_index":index,"item_id":item["id"],"content_index":0,"part":part})));
+                        let mut item = item;
+                        item["content"] = json!([part]);
+                        self.output.push(item);
+                        self.reasoning_index = Some(index);
+                        index
+                    }
+                };
+                if let Value::String(prior) = &mut self.output[index]["content"][0]["text"] {
+                    prior.push_str(text);
+                }
+                events.push_back(self.event("response.reasoning_text.delta", json!({"output_index":index,"item_id":self.output[index]["id"],"content_index":0,"delta":text})));
+            }
             if let Some(text) = delta
                 .get("content")
                 .and_then(Value::as_str)
@@ -208,6 +238,10 @@ impl ResponseStream {
                 let part = &item["content"][0];
                 events.push_back(self.event("response.output_text.done", json!({"output_index": index, "item_id": item["id"], "content_index": 0, "text": part["text"], "logprobs": []})));
                 events.push_back(self.event("response.content_part.done", json!({"output_index": index, "item_id": item["id"], "content_index": 0, "part": part})));
+            } else if item["type"] == "reasoning" {
+                let part = &item["content"][0];
+                events.push_back(self.event("response.reasoning_text.done", json!({"output_index":index,"item_id":item["id"],"content_index":0,"text":part["text"]})));
+                events.push_back(self.event("response.content_part.done", json!({"output_index":index,"item_id":item["id"],"content_index":0,"part":part})));
             } else {
                 events.push_back(self.event("response.function_call_arguments.done", json!({"output_index": index, "item_id": item["id"], "name": item["name"], "arguments": item["arguments"]})));
             }
@@ -249,6 +283,38 @@ impl ResponseStream {
 mod tests {
     use super::*;
 
+    #[test]
+    fn reasoning_events_precede_answer_and_completion() {
+        let mut adapter = ResponseStream::new("model".into());
+        let mut events = adapter.start();
+        events.extend(adapter.push(chunk(json!({"reasoning_content":"Consider "}), Value::Null)));
+        assert_eq!(
+            events.back().unwrap()["type"],
+            "response.reasoning_text.delta"
+        );
+        assert_eq!(events.back().unwrap()["delta"], "Consider ");
+        assert!(
+            !events
+                .iter()
+                .any(|event| event["type"] == "response.completed")
+        );
+        events.extend(adapter.push(chunk(
+            json!({"reasoning_content":"the choices."}),
+            Value::Null,
+        )));
+        events.extend(adapter.push(chunk(json!({"content":"Hello"}), json!("stop"))));
+        events.extend(adapter.finish());
+        let output = &events.back().unwrap()["response"]["output"];
+        assert_eq!(output[0]["type"], "reasoning");
+        assert_eq!(output[0]["content"][0]["text"], "Consider the choices.");
+        assert_eq!(output[1]["content"][0]["text"], "Hello");
+        assert!(
+            events
+                .iter()
+                .any(|event| event["type"] == "response.reasoning_text.done")
+        );
+    }
+
     fn chunk(delta: Value, finish: Value) -> Value {
         json!({"choices": [{"index": 0, "delta": delta, "finish_reason": finish}]})
     }
@@ -269,9 +335,11 @@ mod tests {
         )));
         let meta = json!({"billable": true, "receipt": {"session_id": "server-session", "au_owed_cum": "123"}});
         events.extend(adapter.push(json!({"choices": [], "usage": {"prompt_tokens": 7, "completion_tokens": 5, "total_tokens": 12}, "mayhem": meta})));
-        assert!(!events
-            .iter()
-            .any(|event| event["type"] == "response.completed"));
+        assert!(
+            !events
+                .iter()
+                .any(|event| event["type"] == "response.completed")
+        );
         events.extend(adapter.finish());
         for (sequence, event) in events.iter().enumerate() {
             assert_eq!(event["sequence_number"], sequence);
@@ -325,9 +393,11 @@ mod tests {
                 events.back().unwrap()["response"]["incomplete_details"]["reason"],
                 expected
             );
-            assert!(!events
-                .iter()
-                .any(|event| event["type"] == "response.completed"));
+            assert!(
+                !events
+                    .iter()
+                    .any(|event| event["type"] == "response.completed")
+            );
         }
         let mut adapter = ResponseStream::new("model".to_owned());
         adapter.push(chunk(json!({"content": "partial"}), Value::Null));

--- a/crates/mayhem-gateway/tests/openai_api.rs
+++ b/crates/mayhem-gateway/tests/openai_api.rs
@@ -72,6 +72,7 @@ impl GatewaySessionBackend for TestDirectSessionBackend {
             let completion_tokens = 4;
             Ok(GatewaySessionResult {
                 output: ChatOutput {
+                    reasoning_content: String::new(),
                     content: Some(format!(
                         "direct session response from {} via {}",
                         model.id, invocation.session_id
@@ -143,6 +144,7 @@ impl GatewaySessionBackend for SpecialityRecordingBackend {
             let completion_tokens = 4;
             Ok(GatewaySessionResult {
                 output: ChatOutput {
+                    reasoning_content: String::new(),
                     content: Some(format!("speciality response from {}", model.id)),
                     tool_calls: Vec::new(),
                     artifacts: Vec::new(),
@@ -828,6 +830,7 @@ impl GatewaySessionBackend for ToolCallDirectSessionBackend {
             let completion_tokens = 1;
             Ok(GatewaySessionResult {
                 output: ChatOutput {
+                    reasoning_content: String::new(),
                     content: None,
                     tool_calls: vec![
                         ToolCallOutput {
@@ -878,6 +881,7 @@ impl GatewaySessionBackend for ArtifactDirectSessionBackend {
             let image = b"\x89PNG mayhem artifact".to_vec();
             Ok(GatewaySessionResult {
                 output: ChatOutput {
+                    reasoning_content: String::new(),
                     content: Some(String::new()),
                     tool_calls: Vec::new(),
                     artifacts: vec![GatewayArtifactOutput {
@@ -927,6 +931,7 @@ impl GatewaySessionBackend for VisionInspectBackend {
             let prompt_tokens = request.messages.len() as u64;
             Ok(GatewaySessionResult {
                 output: ChatOutput {
+                    reasoning_content: String::new(),
                     content: Some("vision ok".to_owned()),
                     tool_calls: Vec::new(),
                     artifacts: Vec::new(),
@@ -982,6 +987,7 @@ impl GatewaySessionBackend for RetryThenDirectSessionBackend {
             let completion_tokens = 3;
             Ok(GatewaySessionResult {
                 output: ChatOutput {
+                    reasoning_content: String::new(),
                     content: Some(format!(
                         "direct retry response from {} via {}",
                         model.id, provider
@@ -1040,6 +1046,7 @@ impl GatewaySessionBackend for RetryFirstDirectSessionBackend {
             let completion_tokens = 3;
             Ok(GatewaySessionResult {
                 output: ChatOutput {
+                    reasoning_content: String::new(),
                     content: Some(format!(
                         "direct retry response from {} via {}",
                         model.id, provider
@@ -1152,6 +1159,7 @@ impl GatewaySessionBackend for HedgeInspectBackend {
             let completion_tokens = 2;
             Ok(GatewaySessionResult {
                 output: ChatOutput {
+                    reasoning_content: String::new(),
                     content: Some(format!("hedge inspected for {} via {}", model.id, provider)),
                     tool_calls: Vec::new(),
                     artifacts: Vec::new(),
@@ -1214,6 +1222,7 @@ impl GatewaySessionBackend for CanarySubstitutionBackend {
             let completion_tokens = token_ids.len() as u64;
             Ok(GatewaySessionResult {
                 output: ChatOutput {
+                    reasoning_content: String::new(),
                     content: Some(content),
                     tool_calls: Vec::new(),
                     artifacts: Vec::new(),
@@ -1275,6 +1284,7 @@ impl GatewaySessionBackend for SpecialityCanaryBackend {
             let completion_tokens = token_ids.len() as u64;
             Ok(GatewaySessionResult {
                 output: ChatOutput {
+                    reasoning_content: String::new(),
                     content: Some(format!("{effort} speciality canary output")),
                     tool_calls: Vec::new(),
                     artifacts: Vec::new(),
@@ -1352,6 +1362,7 @@ impl GatewaySessionBackend for ContextNeedleBackend {
             let completion_tokens = token_ids.len() as u64;
             Ok(GatewaySessionResult {
                 output: ChatOutput {
+                    reasoning_content: String::new(),
                     content: Some(content),
                     tool_calls: Vec::new(),
                     artifacts: Vec::new(),


### PR DESCRIPTION
Advertising tools disabled the provider's live token callback, so normal OpenCode requests buffered until generation finished. This change streams answer text, reasoning and tool-argument prefixes during generation across Qwen XML, Gemma native, Mayhem JSON and OpenAI JSON tool formats. Constrained JSON output is classified as answer/tool data instead of waiting for an impossible thinking delimiter.

The gateway exposes `reasoning_content` and Responses reasoning events, bounds incremental tool previews, and validates them against the authoritative final call. The last JSON delimiter is withheld until final validation succeeds. Exact metering evidence stays internal; showing reasoning does not meter it twice. Streaming cancellation preserves acknowledged checkpoint usage on both socket disconnect and explicit job cancellation, then completes signed final settlement.

Model artifacts, tokenizer, prompts, sampling, context, MTP and execution settings are unchanged. Existing calibration records are retained as historical inference evidence, with targeted streaming acceptance added separately. Confirmed Intercom catalog v53 is unchanged; no recalibration or catalog resubmission was needed. Other providers receive the provider-side change through their Core upgrade.

Validation:

- All 541 gateway tests pass on 36acc80; Linux release build passes.
- Three incremental provider parser tests cover every UTF-8 split across all four formats; 51 provider-engine contract tests and 27 receipt regressions pass, including seven real WebSocket cancellation/ACK cases.
- Public Qwen forced write delivered 323 argument fragments, first at 1.975 seconds, across roughly 55 seconds. JSON-schema answers and Responses reasoning also streamed before completion. Completed requests have verified final signatures/ACKs and canonical reservation closures.
- Final-build native cancellation after a checkpoint and public cancellation after live reasoning both automatically settled and released unused reserves. The earlier public test exposed the explicit-cancel checkpoint loss and is retained as failed evidence; its reserve was recovered using an existing provider-signed canonical close, without fabricating a final receipt.
- Final production OpenCode file-read round trip passed in 25.2 seconds, receiving reasoning before the tool call and final answer. All three underlying requests settled with verified final receipts and ledger closures.

Deployed gateway: 36acc80ac2269d3dae173e0bebddf1f7b28c45e4. Owned Qwen provider: 3026748 (later commits change only the gateway). Companion API allowlist update: https://github.com/xNoctem/OpenMayhem_Landing/pull/17. External provider processes were not restarted. These are commit-identified 0.2.172 hotfix builds, not a new public version tag.

Repository-wide CI is not represented as entirely green: existing roster/sellable-audit and dashboard-fixture failures remain outside this change. The original CUDA kernel failure is not proven eliminated; the earlier isolated-worker recovery fix is preserved.
